### PR TITLE
Upgrade Forge GraphQL SDK version to 8.9.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "typescript": "~4.5.5"
   },
   "dependencies": {
-    "@atlassian/forge-graphql": "^8.7.6",
+    "@atlassian/forge-graphql": "^8.9.5",
     "@forge/api": "^2.6.1",
     "@forge/bridge": "^2.3.0",
     "@forge/events": "^0.5.3",

--- a/src/client/compass.ts
+++ b/src/client/compass.ts
@@ -111,9 +111,7 @@ export async function unlinkCompassComponents(cloudId: string, ecosystemAppId: s
 }
 
 export async function getComponentByExternalAlias(input: GetComponentByExternalAliasInput): Promise<ComponentPayload> {
-  const { errors, data } = await graphqlGateway.compass
-    .asApp()
-    .getComponentByExternalAlias({ ...input, externalSource: EXTERNAL_SOURCE });
+  const { errors, data } = await graphqlGateway.compass.asApp().getComponentByExternalAlias({ ...input });
 
   if (errors[0]?.message === COMPASS_GATEWAY_MESSAGES.COMPONENT_NOT_FOUND) {
     return { component: null };

--- a/src/services/fetch-projects.ts
+++ b/src/services/fetch-projects.ts
@@ -2,7 +2,7 @@ import { CreateLinkInput, Link } from '@atlassian/forge-graphql';
 import { storage } from '@forge/api';
 
 import { getComponentByExternalAlias } from '../client/compass';
-import { COMPASS_YML_BRANCH, STORAGE_SECRETS } from '../constants';
+import { COMPASS_YML_BRANCH, EXTERNAL_SOURCE, STORAGE_SECRETS } from '../constants';
 import { getMergeRequests, getProjects, GitLabHeaders } from '../client/gitlab';
 import { GroupProjectsResponse, MergeRequestState, Project, ProjectReadyForImport } from '../types';
 import { getProjectLabels } from './get-labels';
@@ -55,6 +55,7 @@ const compareProjectWithExistingComponent = async (cloudId: string, projectId: n
       getComponentByExternalAlias({
         cloudId,
         externalId: projectId.toString(),
+        externalSource: EXTERNAL_SOURCE,
         options: { includeLinks: true },
       }),
       getMergeRequests(1, 1, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,10 +20,10 @@
     call-me-maybe "^1.0.1"
     js-yaml "^4.1.0"
 
-"@atlassian/forge-graphql@^8.7.6":
-  version "8.7.6"
-  resolved "https://packages.atlassian.com/api/npm/atlassian-npm/@atlassian/forge-graphql/-/forge-graphql-8.7.6.tgz#bef68eeb067052f4a9b5954583fc1c850b8c311b"
-  integrity sha512-EA48QzW+3M32P7aBc/WXtOAdpd/rf6p4UGx8oXRD9BjvKNoKxsjy1j/j+z/u3w3SSo849Wocn5teykQV9wha/A==
+"@atlassian/forge-graphql@^8.9.5":
+  version "8.9.5"
+  resolved "https://packages.atlassian.com/api/npm/atlassian-npm/@atlassian/forge-graphql/-/forge-graphql-8.9.5.tgz#a504e6936ed55bf90b31e75ef93e22e00b11169e"
+  integrity sha512-TePy8NCmJiNygaXwn1N2aEjRlsec3C9mCqyx/REpJ3CDHP4CP+GtEGvoOoD24+ZgKyxer9iE/6L7snBqinTIXw==
   dependencies:
     "@forge/api" "^2.3.0"
     axios "^0.21.1"


### PR DESCRIPTION
Upgrading the Forge GraphQL SDK to the latest version (8.9.5). This version includes a schema change to the `componentByExternalAlias` query, where the `externalSource` field is no longer nullable.