### PR TITLE
Enable "oncall" links for all component types

### DIFF
--- a/src/models/expected-compass-types.ts
+++ b/src/models/expected-compass-types.ts
@@ -53,6 +53,12 @@ export const validFieldKeys = ['tier'];
 
 export const validTierValues = ['1', '2', '3', '4'];
 
-export const validLinkTypes = ['DOCUMENT', 'CHAT_CHANNEL', 'REPOSITORY', 'PROJECT', 'DASHBOARD', 'OTHER_LINK'];
-
-export const validServiceLinkTypes = validLinkTypes.concat('ON_CALL');
+export const validLinkTypes = [
+  'DOCUMENT',
+  'CHAT_CHANNEL',
+  'ON_CALL',
+  'REPOSITORY',
+  'PROJECT',
+  'DASHBOARD',
+  'OTHER_LINK',
+];

--- a/src/services/sync-component-with-file/validate-config-file/config-file-parser.test.ts
+++ b/src/services/sync-component-with-file/validate-config-file/config-file-parser.test.ts
@@ -321,7 +321,7 @@ describe('ConfigFileParser', () => {
         configFileParser.validateLinkProperties(links);
         expect(configFileParser.errors).toEqual([
           '"1" is not a valid link type. The accepted values are: ' +
-            'DOCUMENT, CHAT_CHANNEL, REPOSITORY, PROJECT, DASHBOARD, OTHER_LINK',
+            'DOCUMENT, CHAT_CHANNEL, ON_CALL, REPOSITORY, PROJECT, DASHBOARD, OTHER_LINK',
         ]);
       });
 
@@ -336,7 +336,7 @@ describe('ConfigFileParser', () => {
         configFileParser.validateLinkProperties(links);
         expect(configFileParser.errors).toEqual([
           '"UNKNOWN_TYPE" is not a valid link type. The accepted values are: ' +
-            'DOCUMENT, CHAT_CHANNEL, REPOSITORY, PROJECT, DASHBOARD, OTHER_LINK',
+            'DOCUMENT, CHAT_CHANNEL, ON_CALL, REPOSITORY, PROJECT, DASHBOARD, OTHER_LINK',
         ]);
       });
 
@@ -351,7 +351,7 @@ describe('ConfigFileParser', () => {
         configFileParser.validateLinkProperties(links);
         expect(configFileParser.errors).toEqual([
           '"Loremipsumdolorsitametcon" is not a valid link type. The accepted values are: ' +
-            'DOCUMENT, CHAT_CHANNEL, REPOSITORY, PROJECT, DASHBOARD, OTHER_LINK',
+            'DOCUMENT, CHAT_CHANNEL, ON_CALL, REPOSITORY, PROJECT, DASHBOARD, OTHER_LINK',
         ]);
       });
 
@@ -390,21 +390,6 @@ describe('ConfigFileParser', () => {
 
         serviceConfigFileParser.validateLinkProperties(links);
         expect(serviceConfigFileParser.errors).toEqual([]);
-      });
-
-      test('adds error when type is ON_CALL and component is not a service', () => {
-        const links = [
-          {
-            type: 'ON_CALL',
-            url: 'https://atlassian.com',
-          },
-        ];
-
-        configFileParser.validateLinkProperties(links);
-        expect(configFileParser.errors).toEqual([
-          '"ON_CALL" is not a valid link type. The accepted values are: ' +
-            'DOCUMENT, CHAT_CHANNEL, REPOSITORY, PROJECT, DASHBOARD, OTHER_LINK',
-        ]);
       });
     });
   });

--- a/src/services/sync-component-with-file/validate-config-file/config-file-parser.ts
+++ b/src/services/sync-component-with-file/validate-config-file/config-file-parser.ts
@@ -21,7 +21,6 @@ import {
   serviceFieldKeyTypes,
   types,
   validLinkTypes,
-  validServiceLinkTypes,
   validTierValues,
 } from '../../../models/expected-compass-types';
 import { MAX_DESCRIPTION_LENGTH, MAX_NAME_LENGTH } from '../../../constants';
@@ -257,9 +256,8 @@ export default class ConfigFileParser {
     if (type == null) {
       return;
     }
-    const linkTypes = this.type === CompassComponentType.Service ? validServiceLinkTypes : validLinkTypes;
-    if (typeof type !== 'string' || !linkTypes.includes(type.toUpperCase())) {
-      this.addError(invalidLinkTypeErrorMessage(type, linkTypes));
+    if (typeof type !== 'string' || !validLinkTypes.includes(type.toUpperCase())) {
+      this.addError(invalidLinkTypeErrorMessage(type, validLinkTypes));
     }
   }
 


### PR DESCRIPTION
We are removing the checks for on-call links, as now they are valid for all component types