### PR TITLE
Filter template component type from importer

### DIFF
--- a/ui/src/components/ProjectsImportTable/index.tsx
+++ b/ui/src/components/ProjectsImportTable/index.tsx
@@ -28,6 +28,16 @@ export const ProjectsImportTable = ({
   error,
   componentTypesResult,
 }: Props) => {
+  const TEMPLATE_COMPONENT_TYPE_ID = 'TEMPLATE';
+
+  const getAvailableImportComponentTypes = (availableComponentTypes: ComponentTypesResult) => {
+    const importableComponentTypes = availableComponentTypes;
+    importableComponentTypes.componentTypes = availableComponentTypes.componentTypes?.filter(
+      (componentTypeId) => componentTypeId.id !== TEMPLATE_COMPONENT_TYPE_ID,
+    );
+    return importableComponentTypes;
+  };
+
   const emptyView = useMemo(() => buildEmptyView({ isProjectsExist: projects.length !== 0, error }), [projects, error]);
 
   const isAllItemsSelected = useMemo(
@@ -46,7 +56,12 @@ export const ProjectsImportTable = ({
             isAllItemsSelected,
             isLoading,
           })}
-          rows={buildTableBody({ projects, onSelectItem, onChangeComponentType, componentTypesResult })}
+          rows={buildTableBody({
+            projects,
+            onSelectItem,
+            onChangeComponentType,
+            componentTypesResult: getAvailableImportComponentTypes(componentTypesResult),
+          })}
           loadingSpinnerSize={SPINNER_SIZE}
           isLoading={isLoading}
           emptyView={emptyView}

--- a/ui/src/components/SelectImportPage/screens/__mocks__/mocks.ts
+++ b/ui/src/components/SelectImportPage/screens/__mocks__/mocks.ts
@@ -53,6 +53,18 @@ export const componentTypesResultMock = {
   ],
 };
 
+export const componentTypesWithTemplateResultMock = {
+  componentTypesLoading: false,
+  error: null,
+  componentTypes: [
+    {
+      id: 'SERVICE',
+    },
+    {
+      id: 'TEMPLATE',
+    },
+  ],
+};
 export const componentTypesErrorResultMock = {
   componentTypesLoading: false,
   error: null,

--- a/ui/src/components/SelectImportPage/screens/__tests__/SelectProjectsScreen.test.tsx
+++ b/ui/src/components/SelectImportPage/screens/__tests__/SelectProjectsScreen.test.tsx
@@ -6,6 +6,7 @@ import {
   groupMock,
   componentTypesResultMock,
   componentTypesErrorResultMock,
+  componentTypesWithTemplateResultMock,
 } from '../__mocks__/mocks';
 
 jest.mock('@forge/bridge', () => ({
@@ -129,5 +130,36 @@ describe('SelectProjectsScreen', () => {
     expect(getByTestId('error-loading-component-types'));
     fireEvent.click(getByTestId('error-loading-component-types--button'));
     expect(getByText('Error loading component types. Try refreshing!'));
+  });
+
+  it('should filter out template component type', async () => {
+    const { findByTestId, container, findByText } = render(
+      <SelectProjectsScreen
+        projects={projectImportSelectionMock}
+        isProjectsLoading={false}
+        onSelectAllItems={jest.fn()}
+        onChangeComponentType={jest.fn()}
+        handleNavigateToConnectedPage={jest.fn()}
+        projectsFetchingError=''
+        onSelectItem={jest.fn()}
+        selectedProjects={projectImportSelectionMock}
+        handleNavigateToScreen={jest.fn()}
+        isProjectsImporting
+        totalProjects={1}
+        setPage={jest.fn()}
+        groups={groupMock}
+        isGroupsLoading={false}
+        handleChangeGroup={jest.fn()}
+        handleSearchValue={jest.fn()}
+        componentTypesResult={componentTypesWithTemplateResultMock}
+        locationGroupId={1}
+      />,
+    );
+
+    const select = await findByTestId('select-2');
+    await select.click();
+    expect(await findByText('label')).toBeDefined();
+    const allOptions = await container.getElementsByClassName('type-selector__single-value');
+    expect(allOptions).toHaveLength(1);
   });
 });


### PR DESCRIPTION
# Description

Filtering out `template` component type (in-development feature) from importer as templates cannot be imported.

<img width="1441" alt="image" src="https://user-images.githubusercontent.com/110188568/234334091-ca406a69-2368-437c-9516-c45791b422f2.png">

# Checklist

Please ensure that each of these items has been addressed:

- [x] I have tested these changes in my local environment
- [x] I have added/modified tests as applicable to cover these changes
- [x] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links