### PR TITLE
Add asc sort to getProjectRecentDeployments

### DIFF
--- a/src/client/gitlab.ts
+++ b/src/client/gitlab.ts
@@ -289,6 +289,7 @@ export const getProjectRecentDeployments: GitlabPaginatedFetch<
   const { groupToken, projectId, dateAfter, dateBefore, environmentName } = fetchParameters;
   const params = {
     updated_after: dateAfter,
+    sort: 'asc',
     environment: environmentName,
     page: page.toString(),
     per_page: perPage.toString(),


### PR DESCRIPTION
# Description

Add `sort` parameter to `getProjectRecentDeployments`, this was causing the dataprovider backfill to error out because sort is required if `updated_before` or `updated_after` is specified (https://docs.gitlab.com/ee/api/deployments.html#list-project-deployments maybe a recent change?). 'asc' is the default, so using that. 

# Checklist

Please ensure that each of these items has been addressed:

- [x] I have tested these changes in my local environment
- [ ] I have added/modified tests as applicable to cover these changes
- [x] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links