### PR TITLE
Use order_by when getProjectRecentDeployments

### DIFF
--- a/src/client/gitlab.ts
+++ b/src/client/gitlab.ts
@@ -289,7 +289,7 @@ export const getProjectRecentDeployments: GitlabPaginatedFetch<
   const { groupToken, projectId, dateAfter, dateBefore, environmentName } = fetchParameters;
   const params = {
     updated_after: dateAfter,
-    sort: 'asc',
+    order_by: 'updated_at',
     environment: environmentName,
     page: page.toString(),
     per_page: perPage.toString(),


### PR DESCRIPTION
# Description

Uses `order_by` in `getProjectRecentDeployments` to fix the API call failing (sort wasn't working consistently). Reference: https://docs.gitlab.com/ee/api/deployments.html#list-project-deployments 

Error message: `Gitlab client received a status code of 400 while fetching /api/v4/projects/<project id>/deployments?updated_after=2023-04-11T18%3A55%3A03.486Z&environment=production&page=1&per_page=100 msg: {"message":"400 Bad request - `updated_at` filter requires `updated_at` sort"}` 
# Checklist

Please ensure that each of these items has been addressed:

- [x] I have tested these changes in my local environment
- [ ] I have added/modified tests as applicable to cover these changes
- [x] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links