### PR TITLE
Add stricter URL matching for finding project for link

### DIFF
--- a/src/services/data-provider-link-parser.test.ts
+++ b/src/services/data-provider-link-parser.test.ts
@@ -19,6 +19,7 @@ const mockProjectUrl = 'https://gitlab.com/test/repo-name?testParam=test';
 const testToken1 = 'token1';
 const testToken2 = 'token2';
 const projectName1 = 'project1';
+const projectName1Deleted = 'project1-deleted';
 const projectName2 = 'project2';
 const projectName3 = 'project3';
 const projectName4 = 'project4';
@@ -70,6 +71,25 @@ describe('data-provider-link-parser', () => {
 
     const expectedResult = { project: expectedProjectData, groupToken: testToken2 };
 
+    expect(result).toEqual(expectedResult);
+  });
+
+  it('should match url on both path and name', async () => {
+    const expectedProjectData = generateGitlabProject({
+      id: 1,
+      name: projectName1,
+      web_url: 'https://gitlab.com/test/repo-name',
+    });
+    mockedGetGroupIds.mockResolvedValue([1]);
+    storage.getSecret.mockResolvedValueOnce(testToken1);
+
+    mockedGetOwnedProjectsBySearchCriteria.mockResolvedValueOnce([
+      generateGitlabProject({ id: 2, name: projectName1Deleted, web_url: 'https://gitlab.com/test/repo-name-deleted' }),
+      expectedProjectData,
+    ]);
+
+    const result = await getProjectDataFromUrl(mockProjectUrl);
+    const expectedResult = { project: expectedProjectData, groupToken: testToken1 };
     expect(result).toEqual(expectedResult);
   });
 

--- a/src/services/data-provider-link-parser.ts
+++ b/src/services/data-provider-link-parser.ts
@@ -56,12 +56,11 @@ export const getProjectDataFromUrl = async (
 
     const groupToken = groupTokens[projectsResult.projectIndex];
     const project = projectsResult.projects.find(({ web_url: webUrl }) => webUrl.includes(pathName));
-    console.log(`[getProjectDataFromUrl] project_id: ${project.id}`);
 
     if (!groupToken || !project) {
       throw new Error('Project not found');
     }
-
+    console.log(`[getProjectDataFromUrl] project_id: ${project.id}`);
     return { project, groupToken };
   } catch (e) {
     console.log('Data provider link parser failed', e.message);

--- a/src/services/data-provider-link-parser.ts
+++ b/src/services/data-provider-link-parser.ts
@@ -33,6 +33,7 @@ export const getProjectDataFromUrl = async (
     const { projectName, pathName } = extractProjectInformation(url);
     const groupTokens = await getAllGroupTokens();
 
+    console.log(`url: ${url} groupTokens count: ${groupTokens.length}`);
     const projectsPromiseResults = await Promise.allSettled(
       groupTokens.map((token) => getOwnedProjectsBySearchCriteria(projectName, token)),
     );
@@ -51,9 +52,11 @@ export const getProjectDataFromUrl = async (
       },
       { projects: [], projectIndex: null },
     );
+    console.log(`projectResults count: ${projectsResult.projects.length}`);
 
     const groupToken = groupTokens[projectsResult.projectIndex];
     const project = projectsResult.projects.find(({ web_url: webUrl }) => webUrl.includes(pathName));
+    console.log(`project: ${project.web_url} project_id: ${project.id}`);
 
     if (!groupToken || !project) {
       throw new Error('Project not found');

--- a/src/services/data-provider-link-parser.ts
+++ b/src/services/data-provider-link-parser.ts
@@ -33,7 +33,7 @@ export const getProjectDataFromUrl = async (
     const { projectName, pathName } = extractProjectInformation(url);
     const groupTokens = await getAllGroupTokens();
 
-    console.log(`[getProjectDataFromUrl] url: ${url} groupTokens count: ${groupTokens.length}`);
+    console.log(`[getProjectDataFromUrl] groupTokens count: ${groupTokens.length}`);
     const projectsPromiseResults = await Promise.allSettled(
       groupTokens.map((token) => getOwnedProjectsBySearchCriteria(projectName, token)),
     );
@@ -56,7 +56,7 @@ export const getProjectDataFromUrl = async (
 
     const groupToken = groupTokens[projectsResult.projectIndex];
     const project = projectsResult.projects.find(({ web_url: webUrl }) => webUrl.includes(pathName));
-    console.log(`[getProjectDataFromUrl] project: ${project.web_url} project_id: ${project.id}`);
+    console.log(`[getProjectDataFromUrl] project_id: ${project.id}`);
 
     if (!groupToken || !project) {
       throw new Error('Project not found');

--- a/src/services/data-provider-link-parser.ts
+++ b/src/services/data-provider-link-parser.ts
@@ -33,7 +33,7 @@ export const getProjectDataFromUrl = async (
     const { projectName, pathName } = extractProjectInformation(url);
     const groupTokens = await getAllGroupTokens();
 
-    console.log(`url: ${url} groupTokens count: ${groupTokens.length}`);
+    console.log(`[getProjectDataFromUrl] url: ${url} groupTokens count: ${groupTokens.length}`);
     const projectsPromiseResults = await Promise.allSettled(
       groupTokens.map((token) => getOwnedProjectsBySearchCriteria(projectName, token)),
     );
@@ -52,11 +52,11 @@ export const getProjectDataFromUrl = async (
       },
       { projects: [], projectIndex: null },
     );
-    console.log(`projectResults count: ${projectsResult.projects.length}`);
+    console.log(`[getProjectDataFromUrl] projectResults count: ${projectsResult.projects.length}`);
 
     const groupToken = groupTokens[projectsResult.projectIndex];
     const project = projectsResult.projects.find(({ web_url: webUrl }) => webUrl.includes(pathName));
-    console.log(`project: ${project.web_url} project_id: ${project.id}`);
+    console.log(`[getProjectDataFromUrl] project: ${project.web_url} project_id: ${project.id}`);
 
     if (!groupToken || !project) {
       throw new Error('Project not found');


### PR DESCRIPTION
# Description

When a Gitlab link is added, check that it matches a project's url on both path and name, instead of just checking if the url of the project includes the path 😅 
# Checklist

Please ensure that each of these items has been addressed:

- [x] I have tested these changes in my local environment
- [ ] I have added/modified tests as applicable to cover these changes
- [x] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links