### PR TITLE
Removed template from import options

### DIFF
--- a/ui/src/components/ProjectsImportTable/buildTableBody.tsx
+++ b/ui/src/components/ProjectsImportTable/buildTableBody.tsx
@@ -15,7 +15,7 @@ type Props = {
   projects: ProjectImportSelection[];
   onSelectItem: (id: number) => void;
   onChangeComponentType: (id: number, type: CompassComponentTypeOption) => void;
-  componentTypesResult: ComponentTypesResult;
+  importableComponentTypes: ComponentTypesResult;
 };
 
 const mapStatus = (isManaged: boolean, isCompassFilePrOpened: boolean, hasComponent: boolean) => {
@@ -48,7 +48,7 @@ export const buildTableBody = ({
   projects,
   onSelectItem,
   onChangeComponentType,
-  componentTypesResult,
+  importableComponentTypes,
 }: Props): RowType[] => {
   return projects.map((project) => {
     const {
@@ -114,9 +114,9 @@ export const buildTableBody = ({
           content: (
             <DropdownWrapper data-testid={`select-${id}`}>
               <ComponentTypeSelect
-                loading={componentTypesResult.componentTypesLoading}
+                loading={importableComponentTypes.componentTypesLoading}
                 dropdownId={id.toString()}
-                componentTypes={componentTypesResult.componentTypes}
+                componentTypes={importableComponentTypes.componentTypes}
                 isDisabled={isManaged || isCompassFilePrOpened || hasComponent}
                 selectedOption={typeOption}
                 onChange={(value) =>

--- a/ui/src/components/ProjectsImportTable/index.tsx
+++ b/ui/src/components/ProjectsImportTable/index.tsx
@@ -14,7 +14,7 @@ type Props = {
   onSelectItem: (id: number) => void;
   onChangeComponentType: (id: number, type: CompassComponentTypeOption) => void;
   error?: string;
-  componentTypesResult: ComponentTypesResult;
+  importableComponentTypes: ComponentTypesResult;
 };
 
 const SPINNER_SIZE = 'large';
@@ -26,7 +26,7 @@ export const ProjectsImportTable = ({
   onSelectItem,
   onChangeComponentType,
   error,
-  componentTypesResult,
+  importableComponentTypes,
 }: Props) => {
   const emptyView = useMemo(() => buildEmptyView({ isProjectsExist: projects.length !== 0, error }), [projects, error]);
 
@@ -50,7 +50,7 @@ export const ProjectsImportTable = ({
             projects,
             onSelectItem,
             onChangeComponentType,
-            componentTypesResult,
+            importableComponentTypes,
           })}
           loadingSpinnerSize={SPINNER_SIZE}
           isLoading={isLoading}

--- a/ui/src/components/ProjectsImportTable/index.tsx
+++ b/ui/src/components/ProjectsImportTable/index.tsx
@@ -28,16 +28,6 @@ export const ProjectsImportTable = ({
   error,
   componentTypesResult,
 }: Props) => {
-  const TEMPLATE_COMPONENT_TYPE_ID = 'TEMPLATE';
-
-  const getAvailableImportComponentTypes = (availableComponentTypes: ComponentTypesResult) => {
-    const importableComponentTypes = availableComponentTypes;
-    importableComponentTypes.componentTypes = availableComponentTypes.componentTypes?.filter(
-      (componentTypeId) => componentTypeId.id !== TEMPLATE_COMPONENT_TYPE_ID,
-    );
-    return importableComponentTypes;
-  };
-
   const emptyView = useMemo(() => buildEmptyView({ isProjectsExist: projects.length !== 0, error }), [projects, error]);
 
   const isAllItemsSelected = useMemo(
@@ -60,7 +50,7 @@ export const ProjectsImportTable = ({
             projects,
             onSelectItem,
             onChangeComponentType,
-            componentTypesResult: getAvailableImportComponentTypes(componentTypesResult),
+            componentTypesResult,
           })}
           loadingSpinnerSize={SPINNER_SIZE}
           isLoading={isLoading}

--- a/ui/src/components/SelectImportPage/index.tsx
+++ b/ui/src/components/SelectImportPage/index.tsx
@@ -13,6 +13,7 @@ import { SelectorItem } from './screens/SelectProjectsScreen/buildGroupsSelector
 import { useAppContext } from '../../hooks/useAppContext';
 import { useComponentTypes } from '../../hooks/useComponentTypes';
 import { getComponentTypeOption } from '../utils';
+import { getAvailableImportComponentTypes } from './utils';
 
 export enum Screens {
   CONFIRMATION = 'CONFIRMATION',
@@ -28,6 +29,8 @@ export const SelectImportPage = () => {
   const { getGroups, features } = useAppContext();
   const { setTotalSelectedRepos, setIsImportInProgress, setImportedRepositories } = useImportContext();
   const componentTypesResult = useComponentTypes();
+
+  const importableComponentTypes = getAvailableImportComponentTypes(componentTypesResult);
 
   const [projects, setProjects] = useState<ProjectImportSelection[]>([]);
   const [isProjectsLoading, setIsProjectsLoading] = useState<boolean>(false);
@@ -251,7 +254,7 @@ export const SelectImportPage = () => {
           handleChangeGroup={handleChangeGroup}
           handleSearchValue={handleSearchValue}
           locationGroupId={locationGroupId}
-          componentTypesResult={componentTypesResult}
+          componentTypesResult={importableComponentTypes}
         />
       )}
       {screen === Screens.CONFIRMATION && (
@@ -264,7 +267,7 @@ export const SelectImportPage = () => {
           handleImportProjects={handleImportProjects}
           isProjectsImporting={isProjectsImporting}
           projectsImportingData={projectsImportingData}
-          componentTypesResult={componentTypesResult}
+          componentTypesResult={importableComponentTypes}
         />
       )}
     </>

--- a/ui/src/components/SelectImportPage/index.tsx
+++ b/ui/src/components/SelectImportPage/index.tsx
@@ -254,7 +254,7 @@ export const SelectImportPage = () => {
           handleChangeGroup={handleChangeGroup}
           handleSearchValue={handleSearchValue}
           locationGroupId={locationGroupId}
-          componentTypesResult={importableComponentTypes}
+          importableComponentTypes={importableComponentTypes}
         />
       )}
       {screen === Screens.CONFIRMATION && (
@@ -267,7 +267,7 @@ export const SelectImportPage = () => {
           handleImportProjects={handleImportProjects}
           isProjectsImporting={isProjectsImporting}
           projectsImportingData={projectsImportingData}
-          componentTypesResult={importableComponentTypes}
+          importableComponentTypes={importableComponentTypes}
         />
       )}
     </>

--- a/ui/src/components/SelectImportPage/screens/ConfirmationScreen.tsx
+++ b/ui/src/components/SelectImportPage/screens/ConfirmationScreen.tsx
@@ -15,7 +15,7 @@ type Props = {
   isProjectsImporting: boolean;
   handleImportProjects: () => void;
   projectsImportingData: ResolverResponse | null;
-  componentTypesResult: ComponentTypesResult;
+  importableComponentTypes: ComponentTypesResult;
 };
 
 export const ConfirmationScreen = ({
@@ -27,7 +27,7 @@ export const ConfirmationScreen = ({
   isProjectsImporting,
   handleImportProjects,
   projectsImportingData,
-  componentTypesResult,
+  importableComponentTypes,
 }: Props & SelectedProjectsProps) => {
   return (
     <>
@@ -72,7 +72,7 @@ export const ConfirmationScreen = ({
       <SelectedProjectsTable
         projectsReadyToImport={projectsReadyToImport}
         onChangeComponentType={onChangeComponentType}
-        componentTypesResult={componentTypesResult}
+        importableComponentTypes={importableComponentTypes}
       />
       {projectsImportingData?.errors && projectsImportingData.errors.length !== 0 && (
         <ErrorWrapper>

--- a/ui/src/components/SelectImportPage/screens/SelectProjectsScreen/index.tsx
+++ b/ui/src/components/SelectImportPage/screens/SelectProjectsScreen/index.tsx
@@ -37,7 +37,7 @@ type Props = {
   handleChangeGroup: (item: SelectorItem | null) => void;
   handleSearchValue: (value: string) => void;
   locationGroupId: number;
-  componentTypesResult: ComponentTypesResult;
+  importableComponentTypes: ComponentTypesResult;
 };
 
 export const SelectProjectsScreen = ({
@@ -58,7 +58,7 @@ export const SelectProjectsScreen = ({
   handleChangeGroup,
   handleSearchValue,
   locationGroupId,
-  componentTypesResult,
+  importableComponentTypes,
 }: Props) => {
   const groupSelectorOptions = useMemo(() => buildGroupsSelectorOptions(groups, locationGroupId), [groups]);
 
@@ -95,7 +95,7 @@ export const SelectProjectsScreen = ({
           onSelectItem={onSelectItem}
           onChangeComponentType={onChangeComponentType}
           error={projectsFetchingError}
-          componentTypesResult={componentTypesResult}
+          importableComponentTypes={importableComponentTypes}
         />
         {projects.length !== 0 ? (
           <CenterWrapper>

--- a/ui/src/components/SelectImportPage/screens/__mocks__/mocks.ts
+++ b/ui/src/components/SelectImportPage/screens/__mocks__/mocks.ts
@@ -53,18 +53,6 @@ export const componentTypesResultMock = {
   ],
 };
 
-export const componentTypesWithTemplateResultMock = {
-  componentTypesLoading: false,
-  error: null,
-  componentTypes: [
-    {
-      id: 'SERVICE',
-    },
-    {
-      id: 'TEMPLATE',
-    },
-  ],
-};
 export const componentTypesErrorResultMock = {
   componentTypesLoading: false,
   error: null,

--- a/ui/src/components/SelectImportPage/screens/__tests__/SelectProjectsScreen.test.tsx
+++ b/ui/src/components/SelectImportPage/screens/__tests__/SelectProjectsScreen.test.tsx
@@ -6,7 +6,6 @@ import {
   groupMock,
   componentTypesResultMock,
   componentTypesErrorResultMock,
-  componentTypesWithTemplateResultMock,
 } from '../__mocks__/mocks';
 
 jest.mock('@forge/bridge', () => ({
@@ -130,36 +129,5 @@ describe('SelectProjectsScreen', () => {
     expect(getByTestId('error-loading-component-types'));
     fireEvent.click(getByTestId('error-loading-component-types--button'));
     expect(getByText('Error loading component types. Try refreshing!'));
-  });
-
-  it('should filter out template component type', async () => {
-    const { findByTestId, container, findByText } = render(
-      <SelectProjectsScreen
-        projects={projectImportSelectionMock}
-        isProjectsLoading={false}
-        onSelectAllItems={jest.fn()}
-        onChangeComponentType={jest.fn()}
-        handleNavigateToConnectedPage={jest.fn()}
-        projectsFetchingError=''
-        onSelectItem={jest.fn()}
-        selectedProjects={projectImportSelectionMock}
-        handleNavigateToScreen={jest.fn()}
-        isProjectsImporting
-        totalProjects={1}
-        setPage={jest.fn()}
-        groups={groupMock}
-        isGroupsLoading={false}
-        handleChangeGroup={jest.fn()}
-        handleSearchValue={jest.fn()}
-        componentTypesResult={componentTypesWithTemplateResultMock}
-        locationGroupId={1}
-      />,
-    );
-
-    const select = await findByTestId('select-2');
-    await select.click();
-    expect(await findByText('label')).toBeDefined();
-    const allOptions = await container.getElementsByClassName('type-selector__single-value');
-    expect(allOptions).toHaveLength(1);
   });
 });

--- a/ui/src/components/SelectImportPage/screens/__tests__/SelectProjectsScreen.test.tsx
+++ b/ui/src/components/SelectImportPage/screens/__tests__/SelectProjectsScreen.test.tsx
@@ -39,7 +39,7 @@ describe('SelectProjectsScreen', () => {
         isGroupsLoading={false}
         handleChangeGroup={jest.fn()}
         handleSearchValue={jest.fn()}
-        componentTypesResult={componentTypesResultMock}
+        importableComponentTypes={componentTypesResultMock}
         locationGroupId={1}
       />,
     );
@@ -67,7 +67,7 @@ describe('SelectProjectsScreen', () => {
         isGroupsLoading={false}
         handleChangeGroup={jest.fn()}
         handleSearchValue={jest.fn()}
-        componentTypesResult={componentTypesResultMock}
+        importableComponentTypes={componentTypesResultMock}
         locationGroupId={1}
       />,
     );
@@ -94,7 +94,7 @@ describe('SelectProjectsScreen', () => {
         isGroupsLoading={false}
         handleChangeGroup={jest.fn()}
         handleSearchValue={jest.fn()}
-        componentTypesResult={componentTypesResultMock}
+        importableComponentTypes={componentTypesResultMock}
         locationGroupId={1}
       />,
     );
@@ -121,7 +121,7 @@ describe('SelectProjectsScreen', () => {
         isGroupsLoading={false}
         handleChangeGroup={jest.fn()}
         handleSearchValue={jest.fn()}
-        componentTypesResult={componentTypesErrorResultMock}
+        importableComponentTypes={componentTypesErrorResultMock}
         locationGroupId={1}
       />,
     );

--- a/ui/src/components/SelectImportPage/utils.test.tsx
+++ b/ui/src/components/SelectImportPage/utils.test.tsx
@@ -1,0 +1,30 @@
+import { getAvailableImportComponentTypes } from './utils';
+
+describe('getAvailableImportComponentTypes', () => {
+  it('should filter out TEMPLATE component type', () => {
+    const MOCK_COMPONENT_TYPES_RESULT = {
+      componentTypesLoading: false,
+      error: null,
+      componentTypes: [
+        {
+          id: 'SERVICE',
+        },
+        {
+          id: 'TEMPLATE',
+        },
+      ],
+    };
+    const expected = {
+      componentTypesLoading: false,
+      error: null,
+      componentTypes: [
+        {
+          id: 'SERVICE',
+        },
+      ],
+    };
+    const returned = getAvailableImportComponentTypes(MOCK_COMPONENT_TYPES_RESULT);
+
+    expect(returned).toEqual(expected);
+  });
+});

--- a/ui/src/components/SelectImportPage/utils.ts
+++ b/ui/src/components/SelectImportPage/utils.ts
@@ -1,0 +1,11 @@
+import { ComponentTypesResult } from '../../services/types';
+
+const TEMPLATE_COMPONENT_TYPE_ID = 'TEMPLATE';
+
+export const getAvailableImportComponentTypes = (availableComponentTypes: ComponentTypesResult) => {
+  const importableComponentTypes = availableComponentTypes;
+  importableComponentTypes.componentTypes = availableComponentTypes.componentTypes?.filter(
+    (componentTypeId) => componentTypeId.id !== TEMPLATE_COMPONENT_TYPE_ID,
+  );
+  return importableComponentTypes;
+};

--- a/ui/src/components/SelectedProjectsTable/buildTableBody.tsx
+++ b/ui/src/components/SelectedProjectsTable/buildTableBody.tsx
@@ -8,13 +8,13 @@ import { getComponentTypeOption } from '../utils';
 export interface SelectedProjectsProps {
   projectsReadyToImport: ProjectImportSelection[];
   onChangeComponentType: (id: number, type: CompassComponentTypeOption) => void;
-  componentTypesResult: ComponentTypesResult;
+  importableComponentTypes: ComponentTypesResult;
 }
 
 export const buildTableBody = ({
   projectsReadyToImport,
   onChangeComponentType,
-  componentTypesResult,
+  importableComponentTypes,
 }: SelectedProjectsProps): RowType[] => {
   return projectsReadyToImport.map((project) => {
     return {
@@ -40,9 +40,9 @@ export const buildTableBody = ({
           key: 'type',
           content: (
             <ComponentTypeSelect
-              loading={componentTypesResult.componentTypesLoading}
+              loading={importableComponentTypes.componentTypesLoading}
               dropdownId={project.id.toString()}
-              componentTypes={componentTypesResult.componentTypes}
+              componentTypes={importableComponentTypes.componentTypes}
               isDisabled={project.isManaged || project.isCompassFilePrOpened || project.hasComponent}
               selectedOption={project.typeOption}
               onChange={(value) =>

--- a/ui/src/components/SelectedProjectsTable/index.tsx
+++ b/ui/src/components/SelectedProjectsTable/index.tsx
@@ -8,13 +8,13 @@ export type { SelectedProjectsProps } from './buildTableBody';
 export const SelectedProjectsTable = ({
   projectsReadyToImport,
   onChangeComponentType,
-  componentTypesResult,
+  importableComponentTypes,
 }: SelectedProjectsProps) => {
   return (
     <TableWrapper>
       <DynamicTableStateless
         head={buildTableHead()}
-        rows={buildTableBody({ projectsReadyToImport, onChangeComponentType, componentTypesResult })}
+        rows={buildTableBody({ projectsReadyToImport, onChangeComponentType, importableComponentTypes })}
       />
     </TableWrapper>
   );


### PR DESCRIPTION
# Description

Removed template as an option in both steps of import. Templates cannot be imported.
<img width="1665" alt="Screenshot 2023-05-26 at 10 57 34 AM" src="https://github.com/atlassian-labs/gitlab-for-compass/assets/110188568/3a9a0c69-a5c0-4573-bfb6-068af61b9643">


<img width="1667" alt="Screenshot 2023-05-26 at 10 57 46 AM" src="https://github.com/atlassian-labs/gitlab-for-compass/assets/110188568/dc8df1af-fe74-43d2-90dc-cad84d6fdfe3">

# Checklist

Please ensure that each of these items has been addressed:

- [x] I have tested these changes in my local environment
- [x] I have added/modified tests as applicable to cover these changes
- [x] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links