### PR TITLE
Validate webhook after auth flow

### DIFF
--- a/src/client/gitlab.ts
+++ b/src/client/gitlab.ts
@@ -137,7 +137,7 @@ export const deleteGroupWebhook = async (groupId: number, hookId: number, groupT
   try {
     await callGitlab(`/api/v4/groups/${groupId}/hooks/${hookId}`, groupToken, { method: HttpMethod.DELETE });
   } catch (e) {
-    if (e.message.includes('Not Found')) {
+    if (e.statusText.includes('Not Found')) {
       return;
     }
     throw e;
@@ -154,7 +154,7 @@ export const getGroupWebhook = async (
 
     return webhook;
   } catch (e) {
-    if (e.message.includes('Not Found')) {
+    if (e.statusText.includes('Not Found')) {
       return null;
     }
     throw e;

--- a/src/services/webhook.test.ts
+++ b/src/services/webhook.test.ts
@@ -5,7 +5,7 @@ import { storage, mockForgeApi, webTrigger } from '../__tests__/helpers/forge-he
 mockForgeApi();
 
 import { getGroupWebhook, registerGroupWebhook } from '../client/gitlab';
-import { setupWebhook } from './webhooks';
+import { setupAndValidateWebhook } from './webhooks';
 import { TEST_TOKEN } from '../__tests__/fixtures/gitlab-data';
 
 jest.mock('../client/gitlab');
@@ -27,7 +27,7 @@ describe('webhook service', () => {
     storage.getSecret = jest.fn().mockReturnValueOnce(TEST_TOKEN);
     mockGetGroupWebhook.mockResolvedValue({ id: 456 });
 
-    const result = await setupWebhook(123);
+    const result = await setupAndValidateWebhook(123);
 
     expect(storage.set).not.toHaveBeenCalled();
     expect(result).toBe(MOCK_WEBHOOK_ID);
@@ -39,7 +39,7 @@ describe('webhook service', () => {
     webTrigger.getUrl = jest.fn().mockReturnValue('https://example.com');
     mockRegisterGroupWebhook.mockResolvedValue(MOCK_WEBHOOK_ID);
 
-    const result = await setupWebhook(MOCK_GROUP_ID);
+    const result = await setupAndValidateWebhook(MOCK_GROUP_ID);
 
     expect(mockGetGroupWebhook).not.toHaveBeenCalled();
     expect(storage.set).toHaveBeenNthCalledWith(1, MOCK_WEBHOOK_KEY, MOCK_WEBHOOK_ID);
@@ -54,7 +54,7 @@ describe('webhook service', () => {
     webTrigger.getUrl = jest.fn().mockReturnValue('https://example.com');
     mockRegisterGroupWebhook.mockResolvedValue(MOCK_WEBHOOK_ID);
 
-    const result = await setupWebhook(MOCK_GROUP_ID);
+    const result = await setupAndValidateWebhook(MOCK_GROUP_ID);
 
     expect(storage.set).toHaveBeenNthCalledWith(1, MOCK_WEBHOOK_KEY, MOCK_WEBHOOK_ID);
     expect(storage.set).toHaveBeenNthCalledWith(2, MOCK_WEBHOOK_SIGNATURE_KEY, expect.anything());

--- a/src/services/webhooks.ts
+++ b/src/services/webhooks.ts
@@ -4,7 +4,7 @@ import { registerGroupWebhook, deleteGroupWebhook, getGroupWebhook } from '../cl
 import { GITLAB_EVENT_WEBTRIGGER, STORAGE_KEYS, STORAGE_SECRETS } from '../constants';
 import { generateSignature } from '../utils/generate-signature-utils';
 
-export const setupWebhook = async (groupId: number): Promise<number> => {
+export const setupAndValidateWebhook = async (groupId: number): Promise<number> => {
   const [existingWebhook, groupToken] = await Promise.all([
     storage.get(`${STORAGE_KEYS.WEBHOOK_KEY_PREFIX}${groupId}`),
     storage.getSecret(`${STORAGE_SECRETS.GROUP_TOKEN_KEY_PREFIX}${groupId}`),

--- a/ui/src/components/ConnectedPage/index.tsx
+++ b/ui/src/components/ConnectedPage/index.tsx
@@ -20,7 +20,7 @@ export const ConnectedPage = () => {
   const [groups, setGroups] = useState<GitlabAPIGroup[]>();
 
   const navigate = useNavigate();
-  const { getGroups, clearGroup } = useAppContext();
+  const { getConnectedInfo, clearGroup } = useAppContext();
   const { isImportInProgress } = useImportContext();
 
   const handleDisconnectGroup = async (id: number) => {
@@ -45,7 +45,7 @@ export const ConnectedPage = () => {
   };
 
   useEffect(() => {
-    getGroups().then(setGroups);
+    getConnectedInfo().then(setGroups);
   }, []);
 
   if (errorType) {

--- a/ui/src/components/SelectImportPage/index.tsx
+++ b/ui/src/components/SelectImportPage/index.tsx
@@ -26,7 +26,7 @@ const DEFAULT_GROUP_ID = 0;
 export const SelectImportPage = () => {
   const navigate = useNavigate();
 
-  const { getGroups, features } = useAppContext();
+  const { getConnectedInfo, features } = useAppContext();
   const { setTotalSelectedRepos, setIsImportInProgress, setImportedRepositories } = useImportContext();
   const componentTypesResult = useComponentTypes();
 
@@ -99,7 +99,7 @@ export const SelectImportPage = () => {
 
   useEffect(() => {
     setIsProjectsLoading(true);
-    getGroups()
+    getConnectedInfo()
       .then((value) => {
         if (value) {
           setLocationGroupId(value[0].id);

--- a/ui/src/context/AppContext.tsx
+++ b/ui/src/context/AppContext.tsx
@@ -6,7 +6,7 @@ import { view } from '@forge/bridge';
 import { CenterWrapper } from '../components/styles';
 import { AuthErrorTypes, ErrorTypes, FeaturesList, GitlabAPIGroup } from '../resolverTypes';
 import { ApplicationState } from '../routes';
-import { getForgeAppId, listConnectedGroups } from '../services/invokes';
+import { getForgeAppId, connectedInfo } from '../services/invokes';
 import { DefaultErrorState } from '../components/DefaultErrorState';
 import { useFeatures } from '../hooks/useFeatures';
 
@@ -16,7 +16,7 @@ type AppContextProviderProps = {
 
 export type AppContextProps = {
   initialRoute?: ApplicationState;
-  getGroups: () => Promise<GitlabAPIGroup[] | undefined>;
+  getConnectedInfo: () => Promise<GitlabAPIGroup[] | undefined>;
   clearGroup: (groupId: number) => void;
   features: FeaturesList;
   moduleKey: string;
@@ -63,7 +63,7 @@ export const AppContextProvider: FunctionComponent<AppContextProviderProps> = ({
         setErrorType(AuthErrorTypes.UNEXPECTED_ERROR);
       });
 
-    listConnectedGroups()
+    connectedInfo()
       .then(({ data, success, errors }) => {
         setGroupsLoading(false);
 
@@ -85,13 +85,13 @@ export const AppContextProvider: FunctionComponent<AppContextProviderProps> = ({
       });
   }, []);
 
-  const getGroups = async (): Promise<GitlabAPIGroup[] | undefined> => {
+  const getConnectedInfo = async (): Promise<GitlabAPIGroup[] | undefined> => {
     if (groups && groups?.length > 0) {
       return groups;
     }
 
     try {
-      const { data, success, errors } = await listConnectedGroups();
+      const { data, success, errors } = await connectedInfo();
 
       if (success && data && data.length > 0) {
         setGroups(data);
@@ -126,7 +126,7 @@ export const AppContextProvider: FunctionComponent<AppContextProviderProps> = ({
   }
 
   return (
-    <AppContext.Provider value={{ initialRoute, getGroups, clearGroup, features, moduleKey, appId }}>
+    <AppContext.Provider value={{ initialRoute, getConnectedInfo, clearGroup, features, moduleKey, appId }}>
       {children}
     </AppContext.Provider>
   );

--- a/ui/src/context/__mocks__/mocks.ts
+++ b/ui/src/context/__mocks__/mocks.ts
@@ -4,7 +4,7 @@ export const filledMocks: {
   [key: string]: unknown;
 } = {
   ...defaultMocks,
-  groups: {
+  'groups/connectedInfo': {
     success: true,
     data: [
       {

--- a/ui/src/helpers/mockHelpers.ts
+++ b/ui/src/helpers/mockHelpers.ts
@@ -6,7 +6,7 @@ const getContext: jest.Mock = view.getContext as jest.Mock;
 export const defaultMocks: {
   [key: string]: unknown;
 } = {
-  groups: {
+  'groups/connectedInfo': {
     success: true,
     data: [],
   },

--- a/ui/src/services/invokes.ts
+++ b/ui/src/services/invokes.ts
@@ -16,8 +16,8 @@ export const disconnectGroup = (id: number): Promise<ResolverResponse> => {
   });
 };
 
-export const listConnectedGroups = (): Promise<ResolverResponse<GitlabAPIGroup[]>> => {
-  return invoke<ResolverResponse<GitlabAPIGroup[]>>('groups');
+export const connectedInfo = (): Promise<ResolverResponse<GitlabAPIGroup[]>> => {
+  return invoke<ResolverResponse<GitlabAPIGroup[]>>('groups/connectedInfo');
 };
 
 export const getAllExistingGroups = (): Promise<ResolverResponse<GitlabAPIGroup[]>> => {


### PR DESCRIPTION
# Description

Added webhook handling after auth flow for checking if webhook already exists on the Gitlab side. Also, fixed the issue with the disconnect process if the webhook was manually deleted on the Gitlab side.

# Checklist

Please ensure that each of these items has been addressed:

- [x] I have tested these changes in my local environment
- [x] I have added/modified tests as applicable to cover these changes
- [x] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links