### PR TITLE
Adding a function to truncate the description/display name where project name is too long

### DIFF
--- a/src/services/builds.ts
+++ b/src/services/builds.ts
@@ -1,5 +1,6 @@
 import { CompassBuildEventState, CompassCreateEventInput, DataProviderBuildEvent } from '@atlassian/forge-graphql';
 import { max } from 'lodash';
+import { truncateProjectNameString } from './deployment';
 
 import { GitlabPipelineStates, GitlabApiPipeline, PipelineEvent } from '../types';
 
@@ -47,8 +48,12 @@ export const webhookPipelineEventToCompassBuildEvent = (
       build: {
         externalEventSourceId: pipeline.project.id.toString(),
         updateSequenceNumber: lastUpdated.getTime(),
-        displayName: `${pipeline.project.name} pipeline ${pipeline.object_attributes.id}`,
-        description: `Pipeline run ${pipeline.object_attributes.id} for project ${pipeline.project.name}`,
+        displayName: truncateProjectNameString(``, pipeline.project.name, ` pipeline ${pipeline.object_attributes.id}`),
+        description: truncateProjectNameString(
+          `Pipeline run ${pipeline.object_attributes.id} for project `,
+          pipeline.project.name,
+          ``,
+        ),
         url: `${pipeline.project.web_url}/-/pipelines/${pipeline.object_attributes.id}`,
         lastUpdated: lastUpdated.toISOString(),
         buildProperties: {
@@ -71,8 +76,8 @@ export const gitlabApiPipelineToCompassDataProviderBuildEvent = (
   const isCompleted = !(toCompassBuildState(pipeline.status) === CompassBuildEventState.InProgress);
 
   return {
-    description: `Pipeline run ${pipeline.id} for project ${projectName}`,
-    displayName: `${projectName} pipeline ${pipeline.id}`,
+    description: truncateProjectNameString(`Pipeline run ${pipeline.id} for project `, projectName, ``),
+    displayName: truncateProjectNameString(``, projectName, ` pipeline ${pipeline.id}`),
     state: toCompassBuildState(pipeline.status),
     startedAt: new Date(pipeline.created_at).toISOString(),
     completedAt: isCompleted ? new Date(pipeline.updated_at).toISOString() : null,

--- a/src/services/deployment.ts
+++ b/src/services/deployment.ts
@@ -49,6 +49,18 @@ const isCompletedDeployment = (state: CompassDeploymentEventState) => {
   return state === CompassDeploymentEventState.Failed || state === CompassDeploymentEventState.Successful;
 };
 
+export const DESCRIPTION_TRUNCATION_LENGTH = 255;
+
+export const truncateProjectNameString = (beforeString: string, projectName: string, afterString: string) => {
+  // Spaces need to be included in `beforeString` and `afterString` so they can be considered in string length
+  let truncatedProjectName = projectName;
+  if (beforeString.length + projectName.length + afterString.length > DESCRIPTION_TRUNCATION_LENGTH) {
+    const projectNameLen = DESCRIPTION_TRUNCATION_LENGTH - beforeString.length - afterString.length;
+    truncatedProjectName = projectName.slice(0, projectNameLen);
+  }
+  return `${beforeString}${truncatedProjectName}${afterString}`;
+};
+
 export const gitlabApiDeploymentToCompassDeploymentEvent = (
   deployment: Deployment,
   projectId: number,
@@ -61,10 +73,10 @@ export const gitlabApiDeploymentToCompassDeploymentEvent = (
     cloudId,
     event: {
       deployment: {
-        description: `${projectName} deployment`,
+        description: truncateProjectNameString(``, projectName, ` deployment`),
         externalEventSourceId: projectId.toString(),
         updateSequenceNumber: new Date(deployment.updated_at).getTime(),
-        displayName: `${projectName} deployment ${deployment.id}`,
+        displayName: truncateProjectNameString(``, projectName, ` deployment ${deployment.id}`),
         url: deployment.deployable.pipeline.web_url,
         lastUpdated: new Date(deployment.updated_at).toISOString(),
         deploymentProperties: {
@@ -78,7 +90,7 @@ export const gitlabApiDeploymentToCompassDeploymentEvent = (
           pipeline: {
             pipelineId: deployment.deployable.pipeline.id.toString(),
             url: deployment.deployable.pipeline.web_url,
-            displayName: `${projectName} pipeline`,
+            displayName: truncateProjectNameString(``, projectName, ` pipeline`),
           },
           state: deploymentState,
           sequenceNumber: deployment.id,
@@ -172,14 +184,14 @@ export const gitlabAPiDeploymentToCompassDataProviderDeploymentEvent = (
         environmentId: environment.id.toString(),
       },
       pipeline: {
-        displayName: `${projectName} pipeline`,
+        displayName: truncateProjectNameString(``, projectName, ` pipeline`),
         pipelineId: deployable.pipeline.id.toString(),
         url: deployable.pipeline.web_url,
       },
       sequenceNumber: deployment.id,
       state: gitLabStateToCompassFormat(deployable.status.toUpperCase()),
-      description: `${projectName} deployment`,
-      displayName: `${projectName} deployment ${deployment.id}`,
+      description: truncateProjectNameString(``, projectName, ` deployment`),
+      displayName: truncateProjectNameString(``, projectName, ` deployment ${deployment.id}`),
       lastUpdated: new Date(deployment.updated_at).toISOString(),
       updateSequenceNumber: new Date(deployment.updated_at).getTime(),
       url: deployable.pipeline.web_url,


### PR DESCRIPTION
# Description

This PR is to address the issue that when a project name in GitLab is too long, it causes errors/malfunctions in the data connection established between a Compass component and a GitLab group. GitLab project name limit is 255 characters, while a Compass component (and its various internal fields) have a limit of 100 characters. Thus, where necessary, this PR makes the changes to truncate description and display name fields to ensure that event data continues to be passed properly between GitLab and Compass despite different naming requirements. 

Here is a screenshot showing successful builds appearing in Compass despite a long project name in GitLab: 
<img width="946" alt="Screenshot 2023-08-09 at 2 50 55 PM" src="https://github.com/atlassian-labs/gitlab-for-compass/assets/141262652/0579a4d4-059b-4b39-a591-5bc4d76af353">


# Checklist

Please ensure that each of these items has been addressed:

- [x] I have tested these changes in my local environment
- [ ] I have added/modified tests as applicable to cover these changes
- [x] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links