### PR TITLE
COMPASS-14931 bumping forge version for single/multi select

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "typescript": "~4.5.5"
   },
   "dependencies": {
-    "@atlassian/forge-graphql": "13.0.6",
+    "@atlassian/forge-graphql": "13.3.0",
     "@forge/api": "^2.8.1",
     "@forge/bridge": "^2.3.0",
     "@forge/events": "^0.5.3",

--- a/src/utils/format-custom-fields-to-yaml.ts
+++ b/src/utils/format-custom-fields-to-yaml.ts
@@ -3,6 +3,8 @@ import {
   CompassCustomNumberField,
   CompassCustomTextField,
   CompassCustomUserField,
+  CompassCustomSingleSelectField,
+  CompassCustomMultiSelectField,
   CustomField,
   CustomFieldFromYAML,
   CustomFieldType,
@@ -19,6 +21,15 @@ export const isCompassCustomBooleanField = (customField: CustomField): customFie
 
 export const isCompassCustomUserField = (customField: CustomField): customField is CompassCustomUserField =>
   (customField as CompassCustomUserField).userIdValue !== undefined;
+
+export const isCompassCustomSingleSelectField = (
+  customField: CustomField,
+): customField is CompassCustomSingleSelectField =>
+  (customField as CompassCustomSingleSelectField).option !== undefined;
+
+export const isCompassCustomMultiSelectField = (
+  customField: CustomField,
+): customField is CompassCustomMultiSelectField => (customField as CompassCustomMultiSelectField).options !== undefined;
 
 export const formatCustomFieldsToYamlFormat = (
   customFieldsInComponent: CustomField[],
@@ -55,6 +66,18 @@ export const formatCustomFieldsToYamlFormat = (
     if (isCompassCustomUserField(customField)) {
       mappedCustomFieldToYamlFormat.type = CustomFieldType.USER;
       mappedCustomFieldToYamlFormat.value = customField?.userIdValue || null;
+      return [mappedCustomFieldToYamlFormat];
+    }
+
+    if (isCompassCustomSingleSelectField(customField)) {
+      mappedCustomFieldToYamlFormat.type = CustomFieldType.SINGLE_SELECT;
+      mappedCustomFieldToYamlFormat.value = customField?.option?.id || null;
+      return [mappedCustomFieldToYamlFormat];
+    }
+
+    if (isCompassCustomMultiSelectField(customField)) {
+      mappedCustomFieldToYamlFormat.type = CustomFieldType.MULTI_SELECT;
+      mappedCustomFieldToYamlFormat.value = customField?.options?.map((option) => option.id) || null;
       return [mappedCustomFieldToYamlFormat];
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,15 +20,16 @@
     call-me-maybe "^1.0.1"
     js-yaml "^4.1.0"
 
-"@atlassian/forge-graphql@13.0.6":
-  version "13.0.6"
-  resolved "https://packages.atlassian.com/api/npm/atlassian-npm/@atlassian/forge-graphql/-/forge-graphql-13.0.6.tgz#0f0d69dfaf513f8451558362223d6f00985e57f9"
-  integrity sha512-yZjEdOY0DTXuXx/XwM64SEvZLiVdqhQTprWUFYMwksmn4L/xPFoclggoxo5o3n3xkJtfzVogxqxITUMt0kDtPw==
+"@atlassian/forge-graphql@13.3.0":
+  version "13.3.0"
+  resolved "https://packages.atlassian.com/api/npm/atlassian-npm/@atlassian/forge-graphql/-/forge-graphql-13.3.0.tgz#4711ec64e86739eb31ddb6b7472fb9a3dc449b41"
+  integrity sha512-Z9ZFD/PAfCexEfSYEMAM+Z9X0kocp5sgHcvvcrKcxf7uCMXwFPzagWcWt0q0PF2xoqprq/PQ2TIPSI0oDugXbA==
   dependencies:
     "@forge/api" "^2.3.0"
     axios "^0.21.1"
     fs "^0.0.1-security"
     js-yaml "^4.1.0"
+    lodash "^4.17.21"
     path "^0.12.7"
     url-parse "^1.5.10"
 


### PR DESCRIPTION
# Description

This PR bumps the forge app version and accommodates for single/multiselect custom fields.

# Checklist

Please ensure that each of these items has been addressed:

- [x] I have tested these changes in my local environment
- [ ] I have added/modified tests as applicable to cover these changes
- [x] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links
- [ ] 
<img width="1720" alt="Screenshot 2023-08-15 at 3 09 36 PM" src="https://github.com/atlassian-labs/gitlab-for-compass/assets/142249172/802bdfea-3572-41a2-92a0-ea7668572323">
(connecting a repo in gitlabs creates a branch with an empty `compass.yml file` )

<img width="1718" alt="Screenshot 2023-08-15 at 3 11 01 PM" src="https://github.com/atlassian-labs/gitlab-for-compass/assets/142249172/c19db7c3-223d-448d-ab5d-56c715be5224">
(modifying the compass.yml file with improper UUIDs leads to expected errors)

<img width="395" alt="Screenshot 2023-08-15 at 3 11 49 PM" src="https://github.com/atlassian-labs/gitlab-for-compass/assets/142249172/8c255d94-c1e1-4765-ad06-cc15ff3a2e30">
(modifying the compass.yml file leads to expected changes in single/multiselect fields, link leads to correct file)
