### PR TITLE
use latest forge-graphql to allow for longer component names/descript…

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "typescript": "~4.5.5"
   },
   "dependencies": {
-    "@atlassian/forge-graphql": "13.3.9",
+    "@atlassian/forge-graphql": "13.3.10",
     "@forge/api": "^2.8.1",
     "@forge/bridge": "^2.3.0",
     "@forge/events": "^0.5.3",

--- a/ui/package.json
+++ b/ui/package.json
@@ -19,7 +19,7 @@
     "@atlaskit/textfield": "^5.1.10",
     "@atlaskit/theme": "^12.1.6",
     "@atlaskit/tooltip": "^17.5.9",
-    "@atlassian/forge-graphql": "13.3.9",
+    "@atlassian/forge-graphql": "13.3.10",
     "@forge/api": "^2.8.1",
     "@forge/bridge": "^2.3.0",
     "escape-string-regexp": "^5.0.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -484,10 +484,10 @@
     "@babel/runtime" "^7.0.0"
     "@emotion/core" "^10.0.9"
 
-"@atlassian/forge-graphql@13.3.9":
-  version "13.3.9"
-  resolved "https://packages.atlassian.com/api/npm/atlassian-npm/@atlassian/forge-graphql/-/forge-graphql-13.3.9.tgz#36c0710f1288bbadc527e9dbbdd1726954e6f5ef"
-  integrity sha512-EXyebro9L6rdZNW9bxcCs+vJav0a0k3fSkv0YFgKqML6/hEVLAtHOSt5gc9tMgMr2QhasxLAOlVto/GMG3i/qg==
+"@atlassian/forge-graphql@13.3.10":
+  version "13.3.10"
+  resolved "https://packages.atlassian.com/api/npm/atlassian-npm/@atlassian/forge-graphql/-/forge-graphql-13.3.10.tgz#e5bec74899ca1541068402400f607acb43aedb0c"
+  integrity sha512-q/mCg91f7vtR5G6wQibE+KQKcPYe2u8U6ZJrhhY/jACnbzY5wJrl80DZGGuntC4r+I80XlyaFNX/RXf57AMJLg==
   dependencies:
     "@forge/api" "^2.18.5"
     axios "^1.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,10 +28,10 @@
     call-me-maybe "^1.0.1"
     js-yaml "^4.1.0"
 
-"@atlassian/forge-graphql@13.3.9":
-  version "13.3.9"
-  resolved "https://packages.atlassian.com/api/npm/atlassian-npm/@atlassian/forge-graphql/-/forge-graphql-13.3.9.tgz#36c0710f1288bbadc527e9dbbdd1726954e6f5ef"
-  integrity sha512-EXyebro9L6rdZNW9bxcCs+vJav0a0k3fSkv0YFgKqML6/hEVLAtHOSt5gc9tMgMr2QhasxLAOlVto/GMG3i/qg==
+"@atlassian/forge-graphql@13.3.10":
+  version "13.3.10"
+  resolved "https://packages.atlassian.com/api/npm/atlassian-npm/@atlassian/forge-graphql/-/forge-graphql-13.3.10.tgz#e5bec74899ca1541068402400f607acb43aedb0c"
+  integrity sha512-q/mCg91f7vtR5G6wQibE+KQKcPYe2u8U6ZJrhhY/jACnbzY5wJrl80DZGGuntC4r+I80XlyaFNX/RXf57AMJLg==
   dependencies:
     "@forge/api" "^2.18.5"
     axios "^1.6.0"


### PR DESCRIPTION
# Description

This aligns the component name/description limits with what is currently allowed via the Compass API

# Checklist

Please ensure that each of these items has been addressed:

- [x] I have tested these changes in my local environment
- [x] I have added/modified tests as applicable to cover these changes
- [x] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links