### PR TITLE
Add new module configValidatorWithoutUser

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -20,6 +20,9 @@ modules:
   compass:configValidator:
     - key: config-validator
       function: config-validator-fn
+  compass:configValidatorWithoutUct:
+    - key: config-validator-without-uct
+      function: config-validator-fn
   compass:dataProvider:
     - key: data-provider
       function: data-provider-fn

--- a/manifest.yml
+++ b/manifest.yml
@@ -20,8 +20,8 @@ modules:
   compass:configValidator:
     - key: config-validator
       function: config-validator-fn
-  compass:configValidatorWithoutUct:
-    - key: config-validator-without-uct
+  compass:configValidatorWithoutUser:
+    - key: config-validator-without-user
       function: config-validator-fn
   compass:dataProvider:
     - key: data-provider


### PR DESCRIPTION
# Description

Add new module configValidatorWithoutUser. This allows calls to the config validator functionality without a user.

# Checklist

Please ensure that each of these items has been addressed:

- [x] I have tested these changes in my local environment
- [x] I have added/modified tests as applicable to cover these changes
- [x] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links