### PR TITLE
Truncate gitlab project labels to 40 chars, create util method

### DIFF
--- a/src/client/compass.ts
+++ b/src/client/compass.ts
@@ -21,6 +21,7 @@ import { AggClientError, GraphqlGatewayError } from '../models/errors';
 import { getTenantContextQuery } from './get-tenat-context-query';
 import { aggQuery } from './agg';
 import { getTeamsQuery } from './get-teams-query';
+import { formatLabels } from '../utils/format-labels';
 
 const throwIfErrors = function throwIfSdkErrors(method: string, errors: SdkError[]) {
   // Checking if any invalid config errors to report.
@@ -38,7 +39,7 @@ const throwIfErrors = function throwIfSdkErrors(method: string, errors: SdkError
 
 export const createComponent = async (cloudId: string, project: ImportableProject): Promise<Component | never> => {
   const { name, description, typeId, labels, url, ownerId } = project;
-  const formattedLabels = labels.map((label) => label.split(' ').join('-').toLowerCase());
+  const formattedLabels = formatLabels(labels);
   const component = {
     name,
     description,

--- a/src/resolvers/import-queue-resolver.ts
+++ b/src/resolvers/import-queue-resolver.ts
@@ -9,6 +9,7 @@ import { appendLink } from '../utils/append-link';
 import { ImportableProject } from '../resolverTypes';
 import { sleep } from '../utils/time-utils';
 import { createMRWithCompassYML } from '../services/create-mr-with-compass-yml';
+import { formatLabels } from '../utils/format-labels';
 
 const backOffConfig: Partial<IBackOffOptions> = {
   startingDelay: BACK_OFF.startingDelay,
@@ -67,7 +68,7 @@ resolver.define('import', async (req) => {
         await createMRWithCompassYML(project, component.id, groupId);
       }
     } else if (hasComponent && !(isCompassFilePrOpened && isManaged)) {
-      const formattedLabels = labels.map((label: string) => label.split(' ').join('-').toLowerCase());
+      const formattedLabels = formatLabels(labels);
       const component = {
         name,
         description,

--- a/src/services/sync-component-with-file/sync-component.ts
+++ b/src/services/sync-component-with-file/sync-component.ts
@@ -7,6 +7,7 @@ import { syncComponentWithFile, updateComponent } from '../../client/compass';
 import { getProjectLabels } from '../get-labels';
 import { getProjectById } from '../../client/gitlab';
 import { hasLastSyncEvent } from '../../utils/push-event-utils';
+import { formatLabels } from '../../utils/format-labels';
 
 const getFileUrl = (filePath: string, event: PushEvent, branchName: string) => {
   return `${event.project.web_url}/blob/${branchName}/${filePath}`;
@@ -56,7 +57,7 @@ export const syncComponent = async (
     const { topics } = await getProjectById(token, event.project.id);
     const projectLabels = await getProjectLabels(event.project.id, token, topics);
 
-    const formattedLabels = projectLabels.map((label) => label.split(' ').join('-').toLowerCase());
+    const formattedLabels = formatLabels(projectLabels);
 
     const labels = currentComponent.labels
       ? [...currentComponent.labels, IMPORT_LABEL, ...formattedLabels]

--- a/src/utils/format-labels.test.ts
+++ b/src/utils/format-labels.test.ts
@@ -1,0 +1,39 @@
+import { formatLabels } from './format-labels';
+
+describe('formatLabels', () => {
+  it('should format labels correctly', () => {
+    const input = ['Example Label', 'AnotherExampleLabelThatIsWayTooLongAndShouldBeTruncated'];
+    const expectedOutput = ['example-label', 'anotherexamplelabelthatiswaytoolongandsh'];
+
+    const result = formatLabels(input);
+
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('should handle empty array', () => {
+    const input: string[] = [];
+    const expectedOutput: string[] = [];
+
+    const result = formatLabels(input);
+
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('should not alter labels shorter than 40 characters', () => {
+    const input = ['short', 'medium length label'];
+    const expectedOutput = ['short', 'medium-length-label'];
+
+    const result = formatLabels(input);
+
+    expect(result).toEqual(expectedOutput);
+  });
+
+  it('should convert spaces to hyphens and lowercase all characters', () => {
+    const input = ['Mixed CASE Label', 'Label With Spaces'];
+    const expectedOutput = ['mixed-case-label', 'label-with-spaces'];
+
+    const result = formatLabels(input);
+
+    expect(result).toEqual(expectedOutput);
+  });
+});

--- a/src/utils/format-labels.ts
+++ b/src/utils/format-labels.ts
@@ -1,0 +1,7 @@
+// Converts the topics from a GitLab project to a list of formatted labels for a Compass component.
+export const formatLabels = (labels: string[]): string[] => {
+  return labels.map((label) => {
+    const transformedLabel = label.split(' ').join('-').toLowerCase();
+    return transformedLabel.length > 40 ? transformedLabel.slice(0, 40) : transformedLabel;
+  });
+};


### PR DESCRIPTION
# Description

This truncates GitLab project labels to 40 characters when importing them into Compass because Compass component labels are max 40 characters.

# Checklist

Please ensure that each of these items has been addressed:

- [x] I have tested these changes in my local environment
- [x] I have added/modified tests as applicable to cover these changes
- [x] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links