### PR TITLE
bump forge-graphql to support new component types in config as code

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@atlaskit/tokens": "^1.29.1",
-    "@atlassian/forge-graphql": "13.8.0",
+    "@atlassian/forge-graphql": "13.9.0",
     "@forge/api": "^2.8.1",
     "@forge/bridge": "^2.6.0",
     "@forge/events": "^0.5.3",

--- a/ui/package.json
+++ b/ui/package.json
@@ -22,7 +22,7 @@
     "@atlaskit/theme": "^12.1.6",
     "@atlaskit/tokens": "^1.29.1",
     "@atlaskit/tooltip": "^17.5.9",
-    "@atlassian/forge-graphql": "13.8.0",
+    "@atlassian/forge-graphql": "13.9.0",
     "@forge/api": "^2.8.1",
     "@forge/bridge": "^2.6.0",
     "escape-string-regexp": "^5.0.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -847,10 +847,10 @@
     "@babel/runtime" "^7.0.0"
     "@emotion/react" "^11.7.1"
 
-"@atlassian/forge-graphql@13.8.0":
-  version "13.8.0"
-  resolved "https://packages.atlassian.com/api/npm/atlassian-npm/@atlassian/forge-graphql/-/forge-graphql-13.8.0.tgz#42a0a27bc3d58f7d5039edfa54ad630cb0441594"
-  integrity sha512-S/3KJeg2bypghg8KMRgHvr+JWWlZZs/XyNGMcQQfq3zMt3V9c7bxn0ZHTnhk/OcFEHr/J5kRm7WJlTUWbVgRBw==
+"@atlassian/forge-graphql@13.9.0":
+  version "13.9.0"
+  resolved "https://packages.atlassian.com/api/npm/atlassian-npm/@atlassian/forge-graphql/-/forge-graphql-13.9.0.tgz#e741e7e88e570905f5af3980a0d3c89496e38cc2"
+  integrity sha512-6WgfYfkCZanUrge9phCyt2OZGxTY/SY/VEdufNN4ngIiTcyaeT3ywKoDs/YIkOMk7MxurNCcTlNpC7y+SC0YNQ==
   dependencies:
     "@forge/api" "^2.21.0"
     fs "^0.0.1-security"

--- a/yarn.lock
+++ b/yarn.lock
@@ -79,10 +79,10 @@
     "@babel/types" "^7.20.0"
     bind-event-listener "^2.1.1"
 
-"@atlassian/forge-graphql@13.8.0":
-  version "13.8.0"
-  resolved "https://packages.atlassian.com/api/npm/atlassian-npm/@atlassian/forge-graphql/-/forge-graphql-13.8.0.tgz#42a0a27bc3d58f7d5039edfa54ad630cb0441594"
-  integrity sha512-S/3KJeg2bypghg8KMRgHvr+JWWlZZs/XyNGMcQQfq3zMt3V9c7bxn0ZHTnhk/OcFEHr/J5kRm7WJlTUWbVgRBw==
+"@atlassian/forge-graphql@13.9.0":
+  version "13.9.0"
+  resolved "https://packages.atlassian.com/api/npm/atlassian-npm/@atlassian/forge-graphql/-/forge-graphql-13.9.0.tgz#e741e7e88e570905f5af3980a0d3c89496e38cc2"
+  integrity sha512-6WgfYfkCZanUrge9phCyt2OZGxTY/SY/VEdufNN4ngIiTcyaeT3ywKoDs/YIkOMk7MxurNCcTlNpC7y+SC0YNQ==
   dependencies:
     "@forge/api" "^2.21.0"
     fs "^0.0.1-security"


### PR DESCRIPTION
# Description

We did all the hard work to ship 3 new data related component types, but config as code wasn’t invited to the party 😢. This should fix that.

# Checklist

Please ensure that each of these items has been addressed:

- [x] I have tested these changes in my local environment
- [x] I have added/modified tests as applicable to cover these changes
- [x] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links