### PR TITLE
Change UI for gitlab import so select button does not jump out of screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@atlaskit/primitives": "^12.1.0",
     "@atlaskit/tokens": "^1.29.1",
-    "@atlassian/forge-graphql": "13.9.2",
+    "@atlassian/forge-graphql": "13.10.0",
     "@forge/api": "^2.8.1",
     "@forge/bridge": "^2.6.0",
     "@forge/events": "^0.5.3",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "typescript": "~4.5.5"
   },
   "dependencies": {
+    "@atlaskit/primitives": "^12.1.0",
     "@atlaskit/tokens": "^1.29.1",
     "@atlassian/forge-graphql": "13.9.2",
     "@forge/api": "^2.8.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -14,6 +14,7 @@
     "@atlaskit/icon": "^21.10.6",
     "@atlaskit/inline-message": "^11.4.9",
     "@atlaskit/onboarding": "^11.3.0",
+    "@atlaskit/primitives": "^12.1.0",
     "@atlaskit/progress-bar": "^0.5.6",
     "@atlaskit/section-message": "^6.1.10",
     "@atlaskit/select": "^15.2.11",

--- a/ui/src/components/SelectImportPage/screens/SelectProjectsScreen/index.tsx
+++ b/ui/src/components/SelectImportPage/screens/SelectProjectsScreen/index.tsx
@@ -5,7 +5,6 @@ import Select from '@atlaskit/select';
 import { Search } from '../../../Search';
 import { ProjectsImportTable } from '../../../ProjectsImportTable';
 import {
-  ButtonWrapper,
   GroupSelectorWrapper,
   Header,
   OverrideDescription,
@@ -14,11 +13,13 @@ import {
   Wrapper,
 } from '../../styles';
 import { CompassComponentTypeOption, ComponentTypesResult, ProjectImportSelection } from '../../../../services/types';
-import { CenterWrapper } from '../../../styles';
+import { CenterWrapper, Padding, ButtonWrapper, Divider } from '../../../styles';
 import { GitlabAPIGroup } from '../../../../types';
 import { buildGroupsSelectorOptions, SelectorItem } from './buildGroupsSelectorOptions';
 import { SelectOwnerTeamOption } from '../../../OwnerTeamSelect/types';
 import { TeamsForImportResult } from '../../../../hooks/useTeamsForImport';
+
+const projectsToImportMessage = (projCount: number) => (projCount === 1 ? 'project selected' : 'projects selected');
 
 type Props = {
   projects: ProjectImportSelection[];
@@ -78,42 +79,49 @@ export const SelectProjectsScreen = ({
     <Wrapper data-testid='gitlab-select-projects-screen'>
       <Header>Select projects</Header>
       <OverrideDescription>
-        By importing projects as components, you can track them, manage them via configuration files, <br />
-        and bring in rich, real-time component data such as metrics, directly into Compass.
+        By importing projects as components, you can track them, manage them via configuration files, and bring in rich,
+        real-time component data such as metrics, directly into Compass.
       </OverrideDescription>
-      <>
-        <TableHeaderWrapper>
-          <GroupSelectorWrapper data-testid='group-selector'>
-            <Select
-              isClearable
-              isLoading={isGroupsLoading}
-              isDisabled={isProjectsLoading && !isGroupsLoading}
-              onChange={(e) => handleChangeGroup(e)}
-              inputId='select-group'
-              className='single-select'
-              classNamePrefix='react-select'
-              placeholder='Select group'
-              options={groupSelectorOptions}
-            />
-          </GroupSelectorWrapper>
-          <TableSearchWrapper>
-            <Search handleSearchValue={handleSearchValue} isProjectsLoading={isProjectsLoading} />
-          </TableSearchWrapper>
-        </TableHeaderWrapper>
-        <ProjectsImportTable
-          projects={projects}
-          isLoading={isProjectsLoading && !projects.length}
-          onSelectAllItems={onSelectAllItems}
-          onSelectItem={onSelectItem}
-          onChangeComponentType={onChangeComponentType}
-          error={projectsFetchingError}
-          importableComponentTypes={importableComponentTypes}
-          teamsResult={teamsResult}
-          selectProjectTeam={selectProjectTeam}
-          isSpotlightActive={isSpotlightActive}
-          finishOnboarding={finishOnboarding}
-        />
-        {projects.length !== 0 ? (
+      <TableHeaderWrapper>
+        <GroupSelectorWrapper data-testid='group-selector'>
+          <Select
+            isClearable
+            isLoading={isGroupsLoading}
+            isDisabled={isProjectsLoading && !isGroupsLoading}
+            onChange={(e) => handleChangeGroup(e)}
+            inputId='select-group'
+            className='single-select'
+            classNamePrefix='react-select'
+            placeholder='Select group'
+            options={groupSelectorOptions}
+          />
+        </GroupSelectorWrapper>
+        <TableSearchWrapper>
+          <Search handleSearchValue={handleSearchValue} isProjectsLoading={isProjectsLoading} />
+        </TableSearchWrapper>
+      </TableHeaderWrapper>
+      <ProjectsImportTable
+        projects={projects}
+        isLoading={isProjectsLoading && !projects.length}
+        onSelectAllItems={onSelectAllItems}
+        onSelectItem={onSelectItem}
+        onChangeComponentType={onChangeComponentType}
+        error={projectsFetchingError}
+        importableComponentTypes={importableComponentTypes}
+        teamsResult={teamsResult}
+        selectProjectTeam={selectProjectTeam}
+        isSpotlightActive={isSpotlightActive}
+        finishOnboarding={finishOnboarding}
+      />
+      {projects.length !== 0 ? (
+        <>
+          <Divider />
+          <Padding>
+            <p>
+              <strong>{Object.keys(selectedProjects).length}</strong>{' '}
+              {projectsToImportMessage(Object.keys(selectedProjects).length)}
+            </p>
+          </Padding>
           <CenterWrapper>
             <LoadingButton
               testId='load-more-button'
@@ -123,21 +131,33 @@ export const SelectProjectsScreen = ({
             >
               Load More
             </LoadingButton>
+            {/* {totalProjects > projects.length ? (
+              <LoadingButton
+                testId='load-more-button'
+                isDisabled={totalProjects <= projects.length}
+                onClick={() => setPage((prevPage) => prevPage + 1)}
+                isLoading={!!projects.length && isProjectsLoading}
+              >
+                Load More
+              </LoadingButton>
+            ) : (
+              <Divider />
+            )} */}
           </CenterWrapper>
-        ) : null}
-      </>
 
-      <ButtonWrapper>
-        <Button onClick={() => handleNavigateToConnectedPage()}>Cancel</Button>
-        <LoadingButton
-          appearance='primary'
-          isDisabled={selectedProjects.length === 0}
-          onClick={() => handleNavigateToScreen()}
-          isLoading={isProjectsImporting}
-        >
-          Select
-        </LoadingButton>
-      </ButtonWrapper>
+          <ButtonWrapper>
+            <Button onClick={() => handleNavigateToConnectedPage()}>Cancel</Button>
+            <LoadingButton
+              appearance='primary'
+              isDisabled={selectedProjects.length === 0}
+              onClick={() => handleNavigateToScreen()}
+              isLoading={isProjectsImporting}
+            >
+              Select
+            </LoadingButton>
+          </ButtonWrapper>
+        </>
+      ) : null}
     </Wrapper>
   );
 };

--- a/ui/src/components/SelectImportPage/screens/SelectProjectsScreen/index.tsx
+++ b/ui/src/components/SelectImportPage/screens/SelectProjectsScreen/index.tsx
@@ -133,11 +133,11 @@ export const SelectProjectsScreen = ({
               </Button>
             ) : null}
             <ButtonWrapper>
-              <Button onClick={() => handleNavigateToConnectedPage()}>Cancel</Button>
+              <Button onClick={handleNavigateToConnectedPage}>Cancel</Button>
               <LoadingButton
                 appearance='primary'
                 isDisabled={selectedProjects.length === 0}
-                onClick={() => handleNavigateToScreen()}
+                onClick={handleNavigateToScreen}
                 isLoading={isProjectsImporting}
               >
                 Select

--- a/ui/src/components/SelectImportPage/screens/SelectProjectsScreen/index.tsx
+++ b/ui/src/components/SelectImportPage/screens/SelectProjectsScreen/index.tsx
@@ -2,7 +2,6 @@ import { Dispatch, SetStateAction, useMemo } from 'react';
 import Button, { LoadingButton } from '@atlaskit/button';
 import Select from '@atlaskit/select';
 import { Inline } from '@atlaskit/primitives';
-import { Inline } from '@atlaskit/primitives';
 import Spinner from '@atlaskit/spinner';
 import { Search } from '../../../Search';
 import { ProjectsImportTable } from '../../../ProjectsImportTable';
@@ -15,7 +14,6 @@ import {
   Wrapper,
 } from '../../styles';
 import { CompassComponentTypeOption, ComponentTypesResult, ProjectImportSelection } from '../../../../services/types';
-import { ButtonWrapper, Divider } from '../../../styles';
 import { ButtonWrapper, Divider } from '../../../styles';
 import { GitlabAPIGroup } from '../../../../types';
 import { buildGroupsSelectorOptions, SelectorItem } from './buildGroupsSelectorOptions';
@@ -120,7 +118,6 @@ export const SelectProjectsScreen = ({
         <>
           <Divider />
           <Inline spread='space-between' alignBlock='center'>
-          <Inline spread='space-between' alignBlock='center'>
             <p>
               <strong>{Object.keys(selectedProjects).length}</strong>{' '}
               {projectsToImportMessage(Object.keys(selectedProjects).length)}
@@ -136,11 +133,11 @@ export const SelectProjectsScreen = ({
               </Button>
             ) : null}
             <ButtonWrapper>
-              <Button onClick={() => handleNavigateToConnectedPage()}>Cancel</Button>
+              <Button onClick={handleNavigateToConnectedPage}>Cancel</Button>
               <LoadingButton
                 appearance='primary'
                 isDisabled={selectedProjects.length === 0}
-                onClick={() => handleNavigateToScreen()}
+                onClick={handleNavigateToScreen}
                 isLoading={isProjectsImporting}
               >
                 Select

--- a/ui/src/components/SelectImportPage/screens/SelectProjectsScreen/index.tsx
+++ b/ui/src/components/SelectImportPage/screens/SelectProjectsScreen/index.tsx
@@ -1,7 +1,7 @@
 import { Dispatch, SetStateAction, useMemo } from 'react';
 import Button, { LoadingButton } from '@atlaskit/button';
 import Select from '@atlaskit/select';
-
+import { Inline } from '@atlaskit/primitives';
 import Spinner from '@atlaskit/spinner';
 import { Search } from '../../../Search';
 import { ProjectsImportTable } from '../../../ProjectsImportTable';
@@ -14,7 +14,7 @@ import {
   Wrapper,
 } from '../../styles';
 import { CompassComponentTypeOption, ComponentTypesResult, ProjectImportSelection } from '../../../../services/types';
-import { CenterWrapper, Padding, ButtonWrapper, Divider } from '../../../styles';
+import { ButtonWrapper, Divider } from '../../../styles';
 import { GitlabAPIGroup } from '../../../../types';
 import { buildGroupsSelectorOptions, SelectorItem } from './buildGroupsSelectorOptions';
 import { SelectOwnerTeamOption } from '../../../OwnerTeamSelect/types';
@@ -117,42 +117,35 @@ export const SelectProjectsScreen = ({
       {projects.length !== 0 ? (
         <>
           <Divider />
-          <Padding>
+          <Inline spread='space-between' alignBlock='center'>
             <p>
               <strong>{Object.keys(selectedProjects).length}</strong>{' '}
               {projectsToImportMessage(Object.keys(selectedProjects).length)}
             </p>
-          </Padding>
-          <CenterWrapper>
             {totalProjects > projects.length ? (
-              <ButtonWrapper>
-                <Button
-                  testId={'load-more-button'}
-                  label={'Load More'}
-                  onClick={() => setPage((prevPage) => prevPage + 1)}
-                  isDisabled={totalProjects <= projects.length}
-                >
-                  {!!projects.length && isProjectsLoading ? <Spinner /> : 'Load More'}
-                </Button>
-              </ButtonWrapper>
-            ) : (
-              ''
-            )}
-          </CenterWrapper>
+              <Button
+                testId={'load-more-button'}
+                label={'Load More'}
+                onClick={() => setPage((prevPage) => prevPage + 1)}
+                isDisabled={totalProjects <= projects.length}
+              >
+                {!!projects.length && isProjectsLoading ? <Spinner /> : 'Load More'}
+              </Button>
+            ) : null}
+            <ButtonWrapper>
+              <Button onClick={() => handleNavigateToConnectedPage()}>Cancel</Button>
+              <LoadingButton
+                appearance='primary'
+                isDisabled={selectedProjects.length === 0}
+                onClick={() => handleNavigateToScreen()}
+                isLoading={isProjectsImporting}
+              >
+                Select
+              </LoadingButton>
+            </ButtonWrapper>
+          </Inline>
         </>
       ) : null}
-
-      <ButtonWrapper>
-        <Button onClick={() => handleNavigateToConnectedPage()}>Cancel</Button>
-        <LoadingButton
-          appearance='primary'
-          isDisabled={selectedProjects.length === 0}
-          onClick={() => handleNavigateToScreen()}
-          isLoading={isProjectsImporting}
-        >
-          Select
-        </LoadingButton>
-      </ButtonWrapper>
     </Wrapper>
   );
 };

--- a/ui/src/components/SelectImportPage/screens/SelectProjectsScreen/index.tsx
+++ b/ui/src/components/SelectImportPage/screens/SelectProjectsScreen/index.tsx
@@ -2,6 +2,7 @@ import { Dispatch, SetStateAction, useMemo } from 'react';
 import Button, { LoadingButton } from '@atlaskit/button';
 import Select from '@atlaskit/select';
 
+import Spinner from '@atlaskit/spinner';
 import { Search } from '../../../Search';
 import { ProjectsImportTable } from '../../../ProjectsImportTable';
 import {
@@ -123,41 +124,35 @@ export const SelectProjectsScreen = ({
             </p>
           </Padding>
           <CenterWrapper>
-            <LoadingButton
-              testId='load-more-button'
-              isDisabled={totalProjects <= projects.length}
-              onClick={() => setPage((prevPage) => prevPage + 1)}
-              isLoading={!!projects.length && isProjectsLoading}
-            >
-              Load More
-            </LoadingButton>
-            {/* {totalProjects > projects.length ? (
-              <LoadingButton
-                testId='load-more-button'
-                isDisabled={totalProjects <= projects.length}
-                onClick={() => setPage((prevPage) => prevPage + 1)}
-                isLoading={!!projects.length && isProjectsLoading}
-              >
-                Load More
-              </LoadingButton>
+            {totalProjects > projects.length ? (
+              <ButtonWrapper>
+                <Button
+                  testId={'load-more-button'}
+                  label={'Load More'}
+                  onClick={() => setPage((prevPage) => prevPage + 1)}
+                  isDisabled={totalProjects <= projects.length}
+                >
+                  {!!projects.length && isProjectsLoading ? <Spinner /> : 'Load More'}
+                </Button>
+              </ButtonWrapper>
             ) : (
-              <Divider />
-            )} */}
+              ''
+            )}
           </CenterWrapper>
-
-          <ButtonWrapper>
-            <Button onClick={() => handleNavigateToConnectedPage()}>Cancel</Button>
-            <LoadingButton
-              appearance='primary'
-              isDisabled={selectedProjects.length === 0}
-              onClick={() => handleNavigateToScreen()}
-              isLoading={isProjectsImporting}
-            >
-              Select
-            </LoadingButton>
-          </ButtonWrapper>
         </>
       ) : null}
+
+      <ButtonWrapper>
+        <Button onClick={() => handleNavigateToConnectedPage()}>Cancel</Button>
+        <LoadingButton
+          appearance='primary'
+          isDisabled={selectedProjects.length === 0}
+          onClick={() => handleNavigateToScreen()}
+          isLoading={isProjectsImporting}
+        >
+          Select
+        </LoadingButton>
+      </ButtonWrapper>
     </Wrapper>
   );
 };

--- a/ui/src/components/SelectImportPage/screens/SelectProjectsScreen/index.tsx
+++ b/ui/src/components/SelectImportPage/screens/SelectProjectsScreen/index.tsx
@@ -2,6 +2,7 @@ import { Dispatch, SetStateAction, useMemo } from 'react';
 import Button, { LoadingButton } from '@atlaskit/button';
 import Select from '@atlaskit/select';
 import { Inline } from '@atlaskit/primitives';
+import { Inline } from '@atlaskit/primitives';
 import Spinner from '@atlaskit/spinner';
 import { Search } from '../../../Search';
 import { ProjectsImportTable } from '../../../ProjectsImportTable';
@@ -14,6 +15,7 @@ import {
   Wrapper,
 } from '../../styles';
 import { CompassComponentTypeOption, ComponentTypesResult, ProjectImportSelection } from '../../../../services/types';
+import { ButtonWrapper, Divider } from '../../../styles';
 import { ButtonWrapper, Divider } from '../../../styles';
 import { GitlabAPIGroup } from '../../../../types';
 import { buildGroupsSelectorOptions, SelectorItem } from './buildGroupsSelectorOptions';
@@ -118,6 +120,7 @@ export const SelectProjectsScreen = ({
         <>
           <Divider />
           <Inline spread='space-between' alignBlock='center'>
+          <Inline spread='space-between' alignBlock='center'>
             <p>
               <strong>{Object.keys(selectedProjects).length}</strong>{' '}
               {projectsToImportMessage(Object.keys(selectedProjects).length)}
@@ -133,11 +136,11 @@ export const SelectProjectsScreen = ({
               </Button>
             ) : null}
             <ButtonWrapper>
-              <Button onClick={handleNavigateToConnectedPage}>Cancel</Button>
+              <Button onClick={() => handleNavigateToConnectedPage()}>Cancel</Button>
               <LoadingButton
                 appearance='primary'
                 isDisabled={selectedProjects.length === 0}
-                onClick={handleNavigateToScreen}
+                onClick={() => handleNavigateToScreen()}
                 isLoading={isProjectsImporting}
               >
                 Select

--- a/ui/src/components/SelectImportPage/screens/__tests__/SelectProjectsScreen.test.tsx
+++ b/ui/src/components/SelectImportPage/screens/__tests__/SelectProjectsScreen.test.tsx
@@ -101,8 +101,8 @@ describe('SelectProjectsScreen', () => {
     expect(queryByTestId('load-more-button')).toBeNull();
   });
 
-  it('should disabled load more button when all projects are rendered', () => {
-    const { getByTestId } = render(
+  it('should remove load more button when all projects are rendered', () => {
+    const { queryByTestId } = render(
       <SelectProjectsScreen
         projects={projectImportSelectionMock}
         isProjectsLoading={false}
@@ -127,7 +127,7 @@ describe('SelectProjectsScreen', () => {
       />,
     );
 
-    expect(getByTestId('load-more-button')).toHaveProperty('disabled', true);
+    expect(queryByTestId('load-more-button')).toBeNull();
   });
 
   it('should show an error message per component type dropdown when component types result is empty.', () => {

--- a/ui/src/components/SelectImportPage/styles.ts
+++ b/ui/src/components/SelectImportPage/styles.ts
@@ -9,7 +9,7 @@ export const ButtonWrapper = styled.div`
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  margin: ${gridSize() * 4}px 0px;
+  margin: ${gridSize() * -2}px 0px;
   > button:not(:first-child) {
     margin-left: ${gridSize()}px;
   }

--- a/ui/src/components/styles.ts
+++ b/ui/src/components/styles.ts
@@ -6,21 +6,20 @@ import { gridSize, borderRadius } from '@atlaskit/theme';
 import { token } from '@atlaskit/tokens';
 
 export const Padding = styled.div`
-  // padding: 12px 12px 10px 0;
   margin-top: ${gridSize() * -1}px;
 `;
 
 export const CenterWrapper = styled.div`
   display: flex;
   justify-content: center;
-  margin-top: ${gridSize() * -3}px;
+  margin-top: ${gridSize() * -1}px;
 `;
 
 export const ButtonWrapper = styled.div`
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  margin: ${gridSize() * -4}px 0px;
+  margin: ${gridSize() * -2}px 0px;
   > button:not(:first-child) {
     margin-left: ${gridSize()}px;
     margin-right: ${gridSize()}px;

--- a/ui/src/components/styles.ts
+++ b/ui/src/components/styles.ts
@@ -5,14 +5,9 @@ import { N200, N90, N900, N40 } from '@atlaskit/theme/colors';
 import { gridSize, borderRadius } from '@atlaskit/theme';
 import { token } from '@atlaskit/tokens';
 
-export const Padding = styled.div`
-  margin-top: ${gridSize() * -1}px;
-`;
-
 export const CenterWrapper = styled.div`
   display: flex;
   justify-content: center;
-  margin-top: ${gridSize() * -1}px;
 `;
 
 export const ButtonWrapper = styled.div`

--- a/ui/src/components/styles.ts
+++ b/ui/src/components/styles.ts
@@ -1,13 +1,37 @@
 import styled, { css } from 'styled-components';
 
 import { h400 } from '@atlaskit/theme/typography';
-import { N200, N90, N900 } from '@atlaskit/theme/colors';
-import { gridSize } from '@atlaskit/theme';
+import { N200, N90, N900, N40 } from '@atlaskit/theme/colors';
+import { gridSize, borderRadius } from '@atlaskit/theme';
 import { token } from '@atlaskit/tokens';
+
+export const Padding = styled.div`
+  // padding: 12px 12px 10px 0;
+  margin-top: ${gridSize() * -1}px;
+`;
 
 export const CenterWrapper = styled.div`
   display: flex;
   justify-content: center;
+  margin-top: ${gridSize() * -3}px;
+`;
+
+export const ButtonWrapper = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  margin: ${gridSize() * -4}px 0px;
+  > button:not(:first-child) {
+    margin-left: ${gridSize()}px;
+    margin-right: ${gridSize()}px;
+  }
+`;
+
+export const Divider = styled.hr`
+  border: none;
+  background-color: ${token('color.border', N40)};
+  height: 2px;
+  border-radius: ${borderRadius}px;
 `;
 
 export const SectionWrapper = styled.div`
@@ -65,9 +89,17 @@ const disableLastHeaderCellStylingForSpotlight = css`
 
 export const TableWrapper = styled.div`
   margin-top: ${gridSize() * 4}px;
-  max-height: 60vh;
+  max-height: 65vh;
   overflow: auto;
   padding-right: 12px;
+
+  /* Hide scrollbar */
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+
+  ::-webkit-scrollbar {
+    display: none;
+  }
 
   ${disableLastHeaderCellStylingForSpotlight}
 `;

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -25,6 +25,17 @@
   dependencies:
     tslib "^2.0.0"
 
+"@atlaskit/analytics-next@^10.1.0":
+  version "10.1.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/analytics-next/-/analytics-next-10.1.0.tgz#2616dc9f5b5f7e7c902722b27fdaf364f6c3f94a"
+  integrity sha512-W9vEAzyjij2ghVoU2VJ3QoYMHHbttXe0d6MLYNQUtOsxKSEeEMcgNkjlFXr2oizYGdOu5uPcOIICpw4XK2lYew==
+  dependencies:
+    "@atlaskit/analytics-next-stable-react-context" "1.0.1"
+    "@atlaskit/platform-feature-flags" "^0.3.0"
+    "@babel/runtime" "^7.0.0"
+    prop-types "^15.5.10"
+    use-memo-one "^1.1.1"
+
 "@atlaskit/analytics-next@^8.0.0":
   version "8.3.1"
   resolved "https://registry.yarnpkg.com/@atlaskit/analytics-next/-/analytics-next-8.3.1.tgz#20bb3438ca879b38af6f379aa0b21bcfa5bbc723"
@@ -84,6 +95,15 @@
     "@atlaskit/tokens" "^1.43.0"
     "@babel/runtime" "^7.0.0"
     bind-event-listener "^2.1.1"
+
+"@atlaskit/app-provider@^1.4.0":
+  version "1.4.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/app-provider/-/app-provider-1.4.0.tgz#ee890a3e62209045c7ebc1e5864daa801e7ce4e1"
+  integrity sha512-OheQY4ObKhawVhp2r/tTTL/a1eOa9QTkywaN2YMPEk+HiO3TinSxr3zu162nDlokdPvxo81AyzpAYtWYHBhz0Q==
+  dependencies:
+    "@atlaskit/tokens" "^1.58.0"
+    "@babel/runtime" "^7.0.0"
+    bind-event-listener "^3.0.0"
 
 "@atlaskit/avatar@^21.4.2":
   version "21.4.4"
@@ -231,6 +251,15 @@
     "@babel/runtime" "^7.0.0"
     "@compiled/react" "^0.17.0"
 
+"@atlaskit/css@^0.4.0":
+  version "0.4.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/css/-/css-0.4.0.tgz#a07246537be98ebd3ae862e6dc9788b9e9ab1263"
+  integrity sha512-bg5RaGieN3yRwFHRkk56bZ6/I0dpXNyISRz9rDfbp+yGso8lpIhubmLx4OXfbUUkUEE+9tMWZuEHJXPuCN4jdw==
+  dependencies:
+    "@atlaskit/tokens" "^1.58.0"
+    "@babel/runtime" "^7.0.0"
+    "@compiled/react" "^0.17.2"
+
 "@atlaskit/ds-lib@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@atlaskit/ds-lib/-/ds-lib-1.4.0.tgz#a92387f78a27832821398821e728ef375f992a5d"
@@ -253,6 +282,16 @@
   dependencies:
     "@babel/runtime" "^7.0.0"
     bind-event-listener "^2.1.1"
+
+"@atlaskit/ds-lib@^2.5.0":
+  version "2.5.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-2.5.0.tgz#c90404053e1f671231ede830fa203a70a414e1f7"
+  integrity sha512-HtTyNW2oNcOBhi92Y+QQ4pL7pCU6mTuKVbIUk7cwbxSVUL3XnaUT2hzODhHdDuzumw+DYo0B9z0IB4tZuAc6Iw==
+  dependencies:
+    "@atlaskit/platform-feature-flags" "^0.3.0"
+    "@babel/runtime" "^7.0.0"
+    bind-event-listener "^3.0.0"
+    react-uid "^2.2.0"
 
 "@atlaskit/dynamic-table@^14.5.4":
   version "14.5.4"
@@ -516,6 +555,13 @@
   dependencies:
     "@babel/runtime" "^7.0.0"
 
+"@atlaskit/platform-feature-flags@^0.3.0":
+  version "0.3.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/platform-feature-flags/-/platform-feature-flags-0.3.0.tgz#94dfa0a4ef0a140f6ab0a6de006464de925ecea7"
+  integrity sha512-/0u5fFJ0Rw2j4M5wzsXgaHO6Ey12oekPCDTRvmmAIp4GO9T2Swbl80bavLAPSOmSHMhHTSuvRxiJveZXfQ21IQ==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
 "@atlaskit/popper@^5.0.0":
   version "5.2.5"
   resolved "https://registry.yarnpkg.com/@atlaskit/popper/-/popper-5.2.5.tgz#43e913ef6e70853ae52b25398c85c2b978848ba0"
@@ -560,6 +606,25 @@
   dependencies:
     "@atlaskit/theme" "^12.6.0"
     "@babel/runtime" "^7.0.0"
+
+"@atlaskit/primitives@^12.1.0":
+  version "12.1.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/primitives/-/primitives-12.1.0.tgz#c328847f9c48fce7c1c1cb28764713a2fde6617c"
+  integrity sha512-+zZRWFxY9KIeobXu/6ckMVFM+nqnWnkvvc3PQ34B4x3H7U+ezIolpi+ZAFxQp30Y1P1q6K6SI4o6Te0PAzLyew==
+  dependencies:
+    "@atlaskit/analytics-next" "^10.1.0"
+    "@atlaskit/app-provider" "^1.4.0"
+    "@atlaskit/css" "^0.4.0"
+    "@atlaskit/ds-lib" "^2.5.0"
+    "@atlaskit/interaction-context" "^2.1.0"
+    "@atlaskit/tokens" "^1.59.0"
+    "@atlaskit/visually-hidden" "^1.5.0"
+    "@babel/runtime" "^7.0.0"
+    "@emotion/react" "^11.7.1"
+    "@emotion/serialize" "^1.1.0"
+    bind-event-listener "^3.0.0"
+    react-uid "^2.2.0"
+    tiny-invariant "^1.2.0"
 
 "@atlaskit/primitives@^5.5.0":
   version "5.5.3"
@@ -797,6 +862,18 @@
     "@babel/types" "^7.20.0"
     bind-event-listener "^2.1.1"
 
+"@atlaskit/tokens@^1.58.0", "@atlaskit/tokens@^1.59.0":
+  version "1.59.1"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-1.59.1.tgz#0d01f166f90f20a880cea9d0b7f612c3744e024d"
+  integrity sha512-V4sFrp1MphHFDL5toDS3PMkcnwQoJJbTO/ioGSwvhFq9r46UoDnoaxSljl2ktWdEfdfqTq+ybq8gpKMutojjXA==
+  dependencies:
+    "@atlaskit/ds-lib" "^2.5.0"
+    "@atlaskit/platform-feature-flags" "^0.3.0"
+    "@babel/runtime" "^7.0.0"
+    "@babel/traverse" "^7.23.2"
+    "@babel/types" "^7.20.0"
+    bind-event-listener "^3.0.0"
+
 "@atlaskit/tooltip@^17.5.9":
   version "17.5.9"
   resolved "https://registry.yarnpkg.com/@atlaskit/tooltip/-/tooltip-17.5.9.tgz#d18a2855d17336faa8d08c49ffaf3d136a6770ea"
@@ -843,6 +920,14 @@
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/@atlaskit/visually-hidden/-/visually-hidden-1.2.5.tgz#062a5f0915ae1456740dfa24f329a432f2a019cc"
   integrity sha512-khxJB6456uMS1IkwnsH0ZTYGVAnE83aoGarz388I0zPydOZdNeeEdwsRPFOn9mua88Ez+rL0OEWV22k6XRUf6A==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    "@emotion/react" "^11.7.1"
+
+"@atlaskit/visually-hidden@^1.5.0":
+  version "1.5.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/visually-hidden/-/visually-hidden-1.5.0.tgz#88f6c8e92d62182b680750e890a4af9ce3c084e2"
+  integrity sha512-Khq3mgRcCVwvF8LhDnC4kkmqhYwVcTcAs3YqLGOXufqnoc8H/SD0orjKdFYm1lv8mdz6c1YmyS1zRHCbIXYiDw==
   dependencies:
     "@babel/runtime" "^7.0.0"
     "@emotion/react" "^11.7.1"
@@ -2071,6 +2156,13 @@
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/@compiled/react/-/react-0.17.1.tgz#1ca011b475f25f29331ffe4a171e39bef9f12c9d"
   integrity sha512-1CzTOrwNHOUmz9QGYHv8R8J6ejUyaNYiaUN6/dIM0Wu3G5CIam0KgsqvRikfGPrTtBfAQYMmdI9ytzxUKYwJrg==
+  dependencies:
+    csstype "^3.1.2"
+
+"@compiled/react@^0.17.2":
+  version "0.17.3"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@compiled/react/-/react-0.17.3.tgz#56ec899386f166a731ea3dd00d96786fb64692c2"
+  integrity sha512-aE7U1IGZrmxm/PNIWRcWjER9nYD4XsLoriSVXIFXXT9WMUUk5S82zjoGOwGQ7nirGNNOXgrCbuoS4JMfFVKqSg==
   dependencies:
     csstype "^3.1.2"
 
@@ -4346,6 +4438,11 @@ bind-event-listener@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/bind-event-listener/-/bind-event-listener-2.1.1.tgz#5e57290181af3027ff53ba6109e417a1e3cbb6f3"
   integrity sha512-O+a5c0D2se/u2VlBJmPRn45IB6R4mYMh1ok3dWxrIZ2pmLqzggBhb875mbq73508ylzofc0+hT9W41x4Y2s8lg==
+
+bind-event-listener@^3.0.0:
+  version "3.0.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/bind-event-listener/-/bind-event-listener-3.0.0.tgz#c90f9a7fcb65cac21045f810c20ef7e647a74921"
+  integrity sha512-PJvH288AWQhKs2v9zyfYdPzlPqf5bXbGMmhmUIY9x4dAUGIWgomO771oBQNwJnMQSnUIXhKu6sgzpBRXTlvb8Q==
 
 bluebird@^3.5.5:
   version "3.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -158,30 +158,10 @@
     "@babel/types" "^7.20.0"
     bind-event-listener "^2.1.1"
 
-"@atlaskit/tokens@^1.58.0", "@atlaskit/tokens@^1.59.0":
-  version "1.59.1"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-1.59.1.tgz#0d01f166f90f20a880cea9d0b7f612c3744e024d"
-  integrity sha512-V4sFrp1MphHFDL5toDS3PMkcnwQoJJbTO/ioGSwvhFq9r46UoDnoaxSljl2ktWdEfdfqTq+ybq8gpKMutojjXA==
-  dependencies:
-    "@atlaskit/ds-lib" "^2.5.0"
-    "@atlaskit/platform-feature-flags" "^0.3.0"
-    "@babel/runtime" "^7.0.0"
-    "@babel/traverse" "^7.23.2"
-    "@babel/types" "^7.20.0"
-    bind-event-listener "^3.0.0"
-
-"@atlaskit/visually-hidden@^1.5.0":
-  version "1.5.0"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/visually-hidden/-/visually-hidden-1.5.0.tgz#88f6c8e92d62182b680750e890a4af9ce3c084e2"
-  integrity sha512-Khq3mgRcCVwvF8LhDnC4kkmqhYwVcTcAs3YqLGOXufqnoc8H/SD0orjKdFYm1lv8mdz6c1YmyS1zRHCbIXYiDw==
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-    "@emotion/react" "^11.7.1"
-
-"@atlassian/forge-graphql@13.9.2":
-  version "13.9.2"
-  resolved "https://packages.atlassian.com/api/npm/atlassian-npm/@atlassian/forge-graphql/-/forge-graphql-13.9.2.tgz#9ea2e6882c88d7eb48e3f7a4038a814f376f708e"
-  integrity sha512-Mx4vCx7kBUwD8vGjQkt5e/Hj6DR+kKJhUc+fKkflc48vMN77drWR6AnbAuIVu+44BEsWJU2H0vm2oCAdzVAtQg==
+"@atlassian/forge-graphql@13.10.0":
+  version "13.10.0"
+  resolved "https://packages.atlassian.com/api/npm/atlassian-npm/@atlassian/forge-graphql/-/forge-graphql-13.10.0.tgz#14171310fa04480ea97bcda613e1c784ded29aa3"
+  integrity sha512-F/4EQsZ+DFmM1X8MkFr1QNyvUHGKMXMx4PQiYcpRL3xJTt0X5a1GMl+lbp0Y+ZlelwrrjRMwJX6dX3JQMjAQPQ==
   dependencies:
     "@forge/api" "^2.21.0"
     fs "^0.0.1-security"

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,6 +28,42 @@
     call-me-maybe "^1.0.1"
     js-yaml "^4.1.0"
 
+"@atlaskit/analytics-next-stable-react-context@1.0.1":
+  version "1.0.1"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/analytics-next-stable-react-context/-/analytics-next-stable-react-context-1.0.1.tgz#93c4c7a1a35f4ab606d727af443f49f0842fd96f"
+  integrity sha512-iO6+hIp09dF4iAZQarVz3vKY1kM5Ij5CExYcK9jgc2q+OH8nv8n+BPFeJTdzGOGopmbUZn5Opj9pYQvge1Gr4Q==
+  dependencies:
+    tslib "^2.0.0"
+
+"@atlaskit/analytics-next@^10.1.0":
+  version "10.1.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/analytics-next/-/analytics-next-10.1.0.tgz#2616dc9f5b5f7e7c902722b27fdaf364f6c3f94a"
+  integrity sha512-W9vEAzyjij2ghVoU2VJ3QoYMHHbttXe0d6MLYNQUtOsxKSEeEMcgNkjlFXr2oizYGdOu5uPcOIICpw4XK2lYew==
+  dependencies:
+    "@atlaskit/analytics-next-stable-react-context" "1.0.1"
+    "@atlaskit/platform-feature-flags" "^0.3.0"
+    "@babel/runtime" "^7.0.0"
+    prop-types "^15.5.10"
+    use-memo-one "^1.1.1"
+
+"@atlaskit/app-provider@^1.4.0":
+  version "1.4.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/app-provider/-/app-provider-1.4.0.tgz#ee890a3e62209045c7ebc1e5864daa801e7ce4e1"
+  integrity sha512-OheQY4ObKhawVhp2r/tTTL/a1eOa9QTkywaN2YMPEk+HiO3TinSxr3zu162nDlokdPvxo81AyzpAYtWYHBhz0Q==
+  dependencies:
+    "@atlaskit/tokens" "^1.58.0"
+    "@babel/runtime" "^7.0.0"
+    bind-event-listener "^3.0.0"
+
+"@atlaskit/css@^0.4.0":
+  version "0.4.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/css/-/css-0.4.0.tgz#a07246537be98ebd3ae862e6dc9788b9e9ab1263"
+  integrity sha512-bg5RaGieN3yRwFHRkk56bZ6/I0dpXNyISRz9rDfbp+yGso8lpIhubmLx4OXfbUUkUEE+9tMWZuEHJXPuCN4jdw==
+  dependencies:
+    "@atlaskit/tokens" "^1.58.0"
+    "@babel/runtime" "^7.0.0"
+    "@compiled/react" "^0.17.2"
+
 "@atlaskit/ds-lib@^2.2.0":
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/@atlaskit/ds-lib/-/ds-lib-2.2.3.tgz#fc65a829b45ee0a26c9c6c97072e2d570214aec7"
@@ -35,6 +71,16 @@
   dependencies:
     "@babel/runtime" "^7.0.0"
     bind-event-listener "^2.1.1"
+
+"@atlaskit/ds-lib@^2.5.0":
+  version "2.5.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/ds-lib/-/ds-lib-2.5.0.tgz#c90404053e1f671231ede830fa203a70a414e1f7"
+  integrity sha512-HtTyNW2oNcOBhi92Y+QQ4pL7pCU6mTuKVbIUk7cwbxSVUL3XnaUT2hzODhHdDuzumw+DYo0B9z0IB4tZuAc6Iw==
+  dependencies:
+    "@atlaskit/platform-feature-flags" "^0.3.0"
+    "@babel/runtime" "^7.0.0"
+    bind-event-listener "^3.0.0"
+    react-uid "^2.2.0"
 
 "@atlaskit/eslint-plugin-design-system@^8.7.0":
   version "8.7.0"
@@ -48,12 +94,45 @@
     eslint-codemod-utils "^1.8.6"
     semver "^7.5.2"
 
+"@atlaskit/interaction-context@^2.1.0":
+  version "2.1.5"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/interaction-context/-/interaction-context-2.1.5.tgz#00c06952a50c8ef832a819bef85e17329c6bfcc1"
+  integrity sha512-B+ZR4HES6e8jAZGdwIp3gps0X9LL8Hoe68JXidzzH95RXaLzmwLML+fzZ3iF/PH39OhiRTSlUcJGdWJ6XIl/Fw==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
 "@atlaskit/platform-feature-flags@^0.2.0":
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/@atlaskit/platform-feature-flags/-/platform-feature-flags-0.2.4.tgz#198740b2f3c135cbee023efd96c8009f726d914a"
   integrity sha512-7nmpYu4BiYL3+2sjkqaFh1aho2EtQo69CgIOwpKajrbbMAp4o+MYKIzpofqzZoZk2QBMalsyRYkudG7tWi3+gg==
   dependencies:
     "@babel/runtime" "^7.0.0"
+
+"@atlaskit/platform-feature-flags@^0.3.0":
+  version "0.3.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/platform-feature-flags/-/platform-feature-flags-0.3.0.tgz#94dfa0a4ef0a140f6ab0a6de006464de925ecea7"
+  integrity sha512-/0u5fFJ0Rw2j4M5wzsXgaHO6Ey12oekPCDTRvmmAIp4GO9T2Swbl80bavLAPSOmSHMhHTSuvRxiJveZXfQ21IQ==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
+"@atlaskit/primitives@^12.1.0":
+  version "12.1.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/primitives/-/primitives-12.1.0.tgz#c328847f9c48fce7c1c1cb28764713a2fde6617c"
+  integrity sha512-+zZRWFxY9KIeobXu/6ckMVFM+nqnWnkvvc3PQ34B4x3H7U+ezIolpi+ZAFxQp30Y1P1q6K6SI4o6Te0PAzLyew==
+  dependencies:
+    "@atlaskit/analytics-next" "^10.1.0"
+    "@atlaskit/app-provider" "^1.4.0"
+    "@atlaskit/css" "^0.4.0"
+    "@atlaskit/ds-lib" "^2.5.0"
+    "@atlaskit/interaction-context" "^2.1.0"
+    "@atlaskit/tokens" "^1.59.0"
+    "@atlaskit/visually-hidden" "^1.5.0"
+    "@babel/runtime" "^7.0.0"
+    "@emotion/react" "^11.7.1"
+    "@emotion/serialize" "^1.1.0"
+    bind-event-listener "^3.0.0"
+    react-uid "^2.2.0"
+    tiny-invariant "^1.2.0"
 
 "@atlaskit/tokens@*":
   version "1.22.1"
@@ -78,6 +157,26 @@
     "@babel/traverse" "^7.23.2"
     "@babel/types" "^7.20.0"
     bind-event-listener "^2.1.1"
+
+"@atlaskit/tokens@^1.58.0", "@atlaskit/tokens@^1.59.0":
+  version "1.59.1"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-1.59.1.tgz#0d01f166f90f20a880cea9d0b7f612c3744e024d"
+  integrity sha512-V4sFrp1MphHFDL5toDS3PMkcnwQoJJbTO/ioGSwvhFq9r46UoDnoaxSljl2ktWdEfdfqTq+ybq8gpKMutojjXA==
+  dependencies:
+    "@atlaskit/ds-lib" "^2.5.0"
+    "@atlaskit/platform-feature-flags" "^0.3.0"
+    "@babel/runtime" "^7.0.0"
+    "@babel/traverse" "^7.23.2"
+    "@babel/types" "^7.20.0"
+    bind-event-listener "^3.0.0"
+
+"@atlaskit/visually-hidden@^1.5.0":
+  version "1.5.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/visually-hidden/-/visually-hidden-1.5.0.tgz#88f6c8e92d62182b680750e890a4af9ce3c084e2"
+  integrity sha512-Khq3mgRcCVwvF8LhDnC4kkmqhYwVcTcAs3YqLGOXufqnoc8H/SD0orjKdFYm1lv8mdz6c1YmyS1zRHCbIXYiDw==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    "@emotion/react" "^11.7.1"
 
 "@atlassian/forge-graphql@13.9.2":
   version "13.9.2"
@@ -697,6 +796,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3":
+  version "7.25.6"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@babel/runtime/-/runtime-7.25.6.tgz#9afc3289f7184d8d7f98b099884c26317b9264d2"
+  integrity sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.16.7", "@babel/template@^7.3.3":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
@@ -824,6 +930,13 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
+"@compiled/react@^0.17.2":
+  version "0.17.3"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@compiled/react/-/react-0.17.3.tgz#56ec899386f166a731ea3dd00d96786fb64692c2"
+  integrity sha512-aE7U1IGZrmxm/PNIWRcWjER9nYD4XsLoriSVXIFXXT9WMUUk5S82zjoGOwGQ7nirGNNOXgrCbuoS4JMfFVKqSg==
+  dependencies:
+    csstype "^3.1.2"
+
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
@@ -835,6 +948,94 @@
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
+
+"@emotion/babel-plugin@^11.12.0":
+  version "11.12.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@emotion/babel-plugin/-/babel-plugin-11.12.0.tgz#7b43debb250c313101b3f885eba634f1d723fcc2"
+  integrity sha512-y2WQb+oP8Jqvvclh8Q55gLUyb7UFvgv7eJfsj7td5TToBrIUtPay2kMrZi4xjq9qw2vD0ZR5fSho0yqoFgX7Rw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.16.7"
+    "@babel/runtime" "^7.18.3"
+    "@emotion/hash" "^0.9.2"
+    "@emotion/memoize" "^0.9.0"
+    "@emotion/serialize" "^1.2.0"
+    babel-plugin-macros "^3.1.0"
+    convert-source-map "^1.5.0"
+    escape-string-regexp "^4.0.0"
+    find-root "^1.1.0"
+    source-map "^0.5.7"
+    stylis "4.2.0"
+
+"@emotion/cache@^11.13.0":
+  version "11.13.1"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@emotion/cache/-/cache-11.13.1.tgz#fecfc54d51810beebf05bf2a161271a1a91895d7"
+  integrity sha512-iqouYkuEblRcXmylXIwwOodiEK5Ifl7JcX7o6V4jI3iW4mLXX3dmt5xwBtIkJiQEXFAI+pC8X0i67yiPkH9Ucw==
+  dependencies:
+    "@emotion/memoize" "^0.9.0"
+    "@emotion/sheet" "^1.4.0"
+    "@emotion/utils" "^1.4.0"
+    "@emotion/weak-memoize" "^0.4.0"
+    stylis "4.2.0"
+
+"@emotion/hash@^0.9.2":
+  version "0.9.2"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@emotion/hash/-/hash-0.9.2.tgz#ff9221b9f58b4dfe61e619a7788734bd63f6898b"
+  integrity sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==
+
+"@emotion/memoize@^0.9.0":
+  version "0.9.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@emotion/memoize/-/memoize-0.9.0.tgz#745969d649977776b43fc7648c556aaa462b4102"
+  integrity sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==
+
+"@emotion/react@^11.7.1":
+  version "11.13.3"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@emotion/react/-/react-11.13.3.tgz#a69d0de2a23f5b48e0acf210416638010e4bd2e4"
+  integrity sha512-lIsdU6JNrmYfJ5EbUCf4xW1ovy5wKQ2CkPRM4xogziOxH1nXxBSjpC9YqbFAP7circxMfYp+6x676BqWcEiixg==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@emotion/babel-plugin" "^11.12.0"
+    "@emotion/cache" "^11.13.0"
+    "@emotion/serialize" "^1.3.1"
+    "@emotion/use-insertion-effect-with-fallbacks" "^1.1.0"
+    "@emotion/utils" "^1.4.0"
+    "@emotion/weak-memoize" "^0.4.0"
+    hoist-non-react-statics "^3.3.1"
+
+"@emotion/serialize@^1.1.0", "@emotion/serialize@^1.2.0", "@emotion/serialize@^1.3.1":
+  version "1.3.1"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@emotion/serialize/-/serialize-1.3.1.tgz#490b660178f43d2de8e92b278b51079d726c05c3"
+  integrity sha512-dEPNKzBPU+vFPGa+z3axPRn8XVDetYORmDC0wAiej+TNcOZE70ZMJa0X7JdeoM6q/nWTMZeLpN/fTnD9o8MQBA==
+  dependencies:
+    "@emotion/hash" "^0.9.2"
+    "@emotion/memoize" "^0.9.0"
+    "@emotion/unitless" "^0.10.0"
+    "@emotion/utils" "^1.4.0"
+    csstype "^3.0.2"
+
+"@emotion/sheet@^1.4.0":
+  version "1.4.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@emotion/sheet/-/sheet-1.4.0.tgz#c9299c34d248bc26e82563735f78953d2efca83c"
+  integrity sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==
+
+"@emotion/unitless@^0.10.0":
+  version "0.10.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@emotion/unitless/-/unitless-0.10.0.tgz#2af2f7c7e5150f497bdabd848ce7b218a27cf745"
+  integrity sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==
+
+"@emotion/use-insertion-effect-with-fallbacks@^1.1.0":
+  version "1.1.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.1.0.tgz#1a818a0b2c481efba0cf34e5ab1e0cb2dcb9dfaf"
+  integrity sha512-+wBOcIV5snwGgI2ya3u99D7/FJquOIniQT1IKyDsBmEgwvpxMNeS65Oib7OnE2d2aY+3BU4OiH+0Wchf8yk3Hw==
+
+"@emotion/utils@^1.4.0":
+  version "1.4.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@emotion/utils/-/utils-1.4.0.tgz#262f1d02aaedb2ec91c83a0955dd47822ad5fbdd"
+  integrity sha512-spEnrA1b6hDR/C68lC2M7m6ALPUHZC0lIY7jAS/B/9DuuO1ZP04eov8SMv/6fwRd8pzmsn2AuJEznRREWlQrlQ==
+
+"@emotion/weak-memoize@^0.4.0":
+  version "0.4.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz#5e13fac887f08c44f76b0ccaf3370eb00fec9bb6"
+  integrity sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==
 
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
@@ -1970,6 +2171,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.64.tgz#cd4e41420b77b346695def5a342f6dea0f9d9329"
   integrity sha512-TiY2gIDob8+QOPIcVpS0ZY+H1DVTfplBW6UgL2b4gOYbigIlKVIh6Lcv+7YDUciUTqhVLG91PrZBXW10IoBhtw==
 
+"@types/parse-json@^4.0.0":
+  version "4.0.2"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@types/parse-json/-/parse-json-4.0.2.tgz#5950e50960793055845e956c427fc2b0d70c5239"
+  integrity sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==
+
 "@types/prettier@^2.1.5":
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.6.0.tgz#efcbd41937f9ae7434c714ab698604822d890759"
@@ -2825,6 +3031,15 @@ babel-plugin-jest-hoist@^27.5.1:
     "@types/babel__core" "^7.0.0"
     "@types/babel__traverse" "^7.0.6"
 
+babel-plugin-macros@^3.1.0:
+  version "3.1.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz#9ef6dc74deb934b4db344dc973ee851d148c50c1"
+  integrity sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    cosmiconfig "^7.0.0"
+    resolve "^1.19.0"
+
 babel-preset-current-node-syntax@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz#b4399239b89b2a011f9ddbe3e4f401fc40cff73b"
@@ -2880,6 +3095,11 @@ bind-event-listener@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/bind-event-listener/-/bind-event-listener-2.1.1.tgz#5e57290181af3027ff53ba6109e417a1e3cbb6f3"
   integrity sha512-O+a5c0D2se/u2VlBJmPRn45IB6R4mYMh1ok3dWxrIZ2pmLqzggBhb875mbq73508ylzofc0+hT9W41x4Y2s8lg==
+
+bind-event-listener@^3.0.0:
+  version "3.0.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/bind-event-listener/-/bind-event-listener-3.0.0.tgz#c90f9a7fcb65cac21045f810c20ef7e647a74921"
+  integrity sha512-PJvH288AWQhKs2v9zyfYdPzlPqf5bXbGMmhmUIY9x4dAUGIWgomO771oBQNwJnMQSnUIXhKu6sgzpBRXTlvb8Q==
 
 bl@^4.0.3, bl@^4.1.0:
   version "4.1.0"
@@ -3593,6 +3813,11 @@ convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   dependencies:
     safe-buffer "~5.1.1"
 
+convert-source-map@^1.5.0:
+  version "1.9.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
+  integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
+
 convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
@@ -3617,6 +3842,17 @@ core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
+
+cosmiconfig@^7.0.0:
+  version "7.1.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/cosmiconfig/-/cosmiconfig-7.1.0.tgz#1443b9afa596b670082ea46cbd8f6a62b84635f6"
+  integrity sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==
+  dependencies:
+    "@types/parse-json" "^4.0.0"
+    import-fresh "^3.2.1"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+    yaml "^1.10.0"
 
 crc-32@^1.2.0:
   version "1.2.2"
@@ -3754,6 +3990,11 @@ cssstyle@^2.3.0:
   integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
   dependencies:
     cssom "~0.3.6"
+
+csstype@^3.0.2, csstype@^3.1.2:
+  version "3.1.3"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
+  integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
 d@1, d@^1.0.1:
   version "1.0.1"
@@ -4886,6 +5127,11 @@ find-cache-dir@^3.3.1:
     make-dir "^3.0.2"
     pkg-dir "^4.1.0"
 
+find-root@^1.1.0:
+  version "1.1.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
+  integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
+
 find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
@@ -5398,6 +5644,13 @@ hasown@^2.0.0:
   dependencies:
     function-bind "^1.1.2"
 
+hasown@^2.0.2:
+  version "2.0.2"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
+  integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
+  dependencies:
+    function-bind "^1.1.2"
+
 he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
@@ -5425,6 +5678,13 @@ hmac-drbg@^1.0.1:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
+
+hoist-non-react-statics@^3.3.1:
+  version "3.3.2"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
 
 hpack.js@^2.1.6:
   version "2.1.6"
@@ -5805,6 +6065,13 @@ is-callable@^1.1.4, is-callable@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
   integrity sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==
+
+is-core-module@^2.13.0:
+  version "2.15.1"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/is-core-module/-/is-core-module-2.15.1.tgz#a7363a25bee942fefab0de13bf6aa372c82dcc37"
+  integrity sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==
+  dependencies:
+    hasown "^2.0.2"
 
 is-core-module@^2.2.0, is-core-module@^2.8.1:
   version "2.9.0"
@@ -7703,7 +7970,7 @@ parse-asn1@^5.0.0, parse-asn1@^5.1.5:
     pbkdf2 "^3.0.3"
     safe-buffer "^5.1.1"
 
-parse-json@^5.2.0:
+parse-json@^5.0.0, parse-json@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
   integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
@@ -7937,7 +8204,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.8.1:
+prop-types@^15.5.10, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -8083,7 +8350,7 @@ rc@1.2.8, rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-is@^16.13.1:
+react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -8107,6 +8374,13 @@ react-router@6.3.0:
   integrity sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==
   dependencies:
     history "^5.2.0"
+
+react-uid@^2.2.0:
+  version "2.3.3"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/react-uid/-/react-uid-2.3.3.tgz#6a485ccc868555997f3506c6db97a3e735d97adf"
+  integrity sha512-iNpDovcb9qBpBTo8iUgqRSQOS8GV3bWoNaTaUptHkXtAooXSo0OWe7vN6TqqB8x3x0bNBbQx96kkmSltQ5h9kQ==
+  dependencies:
+    tslib "^2.0.0"
 
 react@^17.0.2:
   version "17.0.2"
@@ -8303,6 +8577,15 @@ resolve.exports@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-1.1.0.tgz#5ce842b94b05146c0e03076985d1d0e7e48c90c9"
   integrity sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==
+
+resolve@^1.19.0:
+  version "1.22.8"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
+  integrity sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
+  dependencies:
+    is-core-module "^2.13.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
 
 resolve@^1.20.0, resolve@^1.22.0:
   version "1.22.0"
@@ -8739,6 +9022,11 @@ source-map-support@^0.5.6, source-map-support@~0.5.20:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
+source-map@^0.5.7:
+  version "0.5.7"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+  integrity sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==
+
 source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
@@ -8820,7 +9108,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8837,6 +9125,15 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.0, string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -8920,7 +9217,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -8933,6 +9230,13 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.0.1"
@@ -8965,6 +9269,11 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
+stylis@4.2.0:
+  version "4.2.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/stylis/-/stylis-4.2.0.tgz#79daee0208964c8fe695a42fcffcac633a211a51"
+  integrity sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==
 
 supports-color@^5.3.0:
   version "5.5.0"
@@ -9147,6 +9456,11 @@ tiny-each-async@2.0.3:
   resolved "https://registry.yarnpkg.com/tiny-each-async/-/tiny-each-async-2.0.3.tgz#8ebbbfd6d6295f1370003fbb37162afe5a0a51d1"
   integrity sha1-jru/1tYpXxNwAD+7NxYq/loKUdE=
 
+tiny-invariant@^1.2.0:
+  version "1.3.3"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
+  integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -9286,6 +9600,11 @@ tslib@^1.11.0, tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.0.0:
+  version "2.7.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/tslib/-/tslib-2.7.0.tgz#d9b40c5c40ab59e8738f297df3087bf1a2690c01"
+  integrity sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==
 
 tslib@^2.0.3, tslib@^2.6.2:
   version "2.6.2"
@@ -9493,6 +9812,11 @@ url@^0.11.3:
   dependencies:
     punycode "^1.4.1"
     qs "^6.11.2"
+
+use-memo-one@^1.1.1:
+  version "1.1.3"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/use-memo-one/-/use-memo-one-1.1.3.tgz#2fd2e43a2169eabc7496960ace8c79efef975e99"
+  integrity sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==
 
 utf8-byte-length@^1.0.1:
   version "1.0.4"
@@ -9866,8 +10190,7 @@ word-wrap@^1.2.3, word-wrap@~1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
-  name wrap-ansi-cjs
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -9880,6 +10203,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -9958,7 +10290,7 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@^1.10.2:
+yaml@^1.10.0, yaml@^1.10.2:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -157,6 +157,26 @@
     "@babel/types" "^7.20.0"
     bind-event-listener "^2.1.1"
 
+"@atlaskit/tokens@^1.58.0", "@atlaskit/tokens@^1.59.0":
+  version "1.59.1"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-1.59.1.tgz#0d01f166f90f20a880cea9d0b7f612c3744e024d"
+  integrity sha512-V4sFrp1MphHFDL5toDS3PMkcnwQoJJbTO/ioGSwvhFq9r46UoDnoaxSljl2ktWdEfdfqTq+ybq8gpKMutojjXA==
+  dependencies:
+    "@atlaskit/ds-lib" "^2.5.0"
+    "@atlaskit/platform-feature-flags" "^0.3.0"
+    "@babel/runtime" "^7.0.0"
+    "@babel/traverse" "^7.23.2"
+    "@babel/types" "^7.20.0"
+    bind-event-listener "^3.0.0"
+
+"@atlaskit/visually-hidden@^1.5.0":
+  version "1.5.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/visually-hidden/-/visually-hidden-1.5.0.tgz#88f6c8e92d62182b680750e890a4af9ce3c084e2"
+  integrity sha512-Khq3mgRcCVwvF8LhDnC4kkmqhYwVcTcAs3YqLGOXufqnoc8H/SD0orjKdFYm1lv8mdz6c1YmyS1zRHCbIXYiDw==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    "@emotion/react" "^11.7.1"
+
 "@atlassian/forge-graphql@13.10.0":
   version "13.10.0"
   resolved "https://packages.atlassian.com/api/npm/atlassian-npm/@atlassian/forge-graphql/-/forge-graphql-13.10.0.tgz#14171310fa04480ea97bcda613e1c784ded29aa3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -116,9 +116,9 @@
     "@babel/runtime" "^7.0.0"
 
 "@atlaskit/primitives@^12.1.0":
-  version "12.1.0"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/primitives/-/primitives-12.1.0.tgz#c328847f9c48fce7c1c1cb28764713a2fde6617c"
-  integrity sha512-+zZRWFxY9KIeobXu/6ckMVFM+nqnWnkvvc3PQ34B4x3H7U+ezIolpi+ZAFxQp30Y1P1q6K6SI4o6Te0PAzLyew==
+  version "12.1.1"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/primitives/-/primitives-12.1.1.tgz#04a3667cdaae4188e8ba096a10a66bbfe14e1e43"
+  integrity sha512-sTH9O1QW+RsjUlXQJ8zX2JvBKYOUfEbY35TPFEjS8y9k6Tm5R+L9M85F/Kn/hXby765k5lzUOVkIya/DKv3jJA==
   dependencies:
     "@atlaskit/analytics-next" "^10.1.0"
     "@atlaskit/app-provider" "^1.4.0"
@@ -131,7 +131,6 @@
     "@emotion/react" "^11.7.1"
     "@emotion/serialize" "^1.1.0"
     bind-event-listener "^3.0.0"
-    react-uid "^2.2.0"
     tiny-invariant "^1.2.0"
 
 "@atlaskit/tokens@*":
@@ -7952,7 +7951,7 @@ parse-asn1@^5.0.0, parse-asn1@^5.1.5:
 
 parse-json@^5.0.0, parse-json@^5.2.0:
   version "5.2.0"
-  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
   integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
   dependencies:
     "@babel/code-frame" "^7.0.0"
@@ -8186,7 +8185,7 @@ prompts@^2.0.1:
 
 prop-types@^15.5.10, prop-types@^15.8.1:
   version "15.8.1"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
   dependencies:
     loose-envify "^1.4.0"
@@ -10272,7 +10271,7 @@ yallist@^4.0.0:
 
 yaml@^1.10.0, yaml@^1.10.2:
   version "1.10.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yaml@^2.2.2, yaml@^2.3.4:

--- a/yarn.lock
+++ b/yarn.lock
@@ -158,10 +158,30 @@
     "@babel/types" "^7.20.0"
     bind-event-listener "^2.1.1"
 
-"@atlassian/forge-graphql@13.10.0":
-  version "13.10.0"
-  resolved "https://packages.atlassian.com/api/npm/atlassian-npm/@atlassian/forge-graphql/-/forge-graphql-13.10.0.tgz#14171310fa04480ea97bcda613e1c784ded29aa3"
-  integrity sha512-F/4EQsZ+DFmM1X8MkFr1QNyvUHGKMXMx4PQiYcpRL3xJTt0X5a1GMl+lbp0Y+ZlelwrrjRMwJX6dX3JQMjAQPQ==
+"@atlaskit/tokens@^1.58.0", "@atlaskit/tokens@^1.59.0":
+  version "1.59.1"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/tokens/-/tokens-1.59.1.tgz#0d01f166f90f20a880cea9d0b7f612c3744e024d"
+  integrity sha512-V4sFrp1MphHFDL5toDS3PMkcnwQoJJbTO/ioGSwvhFq9r46UoDnoaxSljl2ktWdEfdfqTq+ybq8gpKMutojjXA==
+  dependencies:
+    "@atlaskit/ds-lib" "^2.5.0"
+    "@atlaskit/platform-feature-flags" "^0.3.0"
+    "@babel/runtime" "^7.0.0"
+    "@babel/traverse" "^7.23.2"
+    "@babel/types" "^7.20.0"
+    bind-event-listener "^3.0.0"
+
+"@atlaskit/visually-hidden@^1.5.0":
+  version "1.5.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@atlaskit/visually-hidden/-/visually-hidden-1.5.0.tgz#88f6c8e92d62182b680750e890a4af9ce3c084e2"
+  integrity sha512-Khq3mgRcCVwvF8LhDnC4kkmqhYwVcTcAs3YqLGOXufqnoc8H/SD0orjKdFYm1lv8mdz6c1YmyS1zRHCbIXYiDw==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    "@emotion/react" "^11.7.1"
+
+"@atlassian/forge-graphql@13.9.2":
+  version "13.9.2"
+  resolved "https://packages.atlassian.com/api/npm/atlassian-npm/@atlassian/forge-graphql/-/forge-graphql-13.9.2.tgz#9ea2e6882c88d7eb48e3f7a4038a814f376f708e"
+  integrity sha512-Mx4vCx7kBUwD8vGjQkt5e/Hj6DR+kKJhUc+fKkflc48vMN77drWR6AnbAuIVu+44BEsWJU2H0vm2oCAdzVAtQg==
   dependencies:
     "@forge/api" "^2.21.0"
     fs "^0.0.1-security"

--- a/yarn.lock
+++ b/yarn.lock
@@ -178,10 +178,10 @@
     "@babel/runtime" "^7.0.0"
     "@emotion/react" "^11.7.1"
 
-"@atlassian/forge-graphql@13.9.2":
-  version "13.9.2"
-  resolved "https://packages.atlassian.com/api/npm/atlassian-npm/@atlassian/forge-graphql/-/forge-graphql-13.9.2.tgz#9ea2e6882c88d7eb48e3f7a4038a814f376f708e"
-  integrity sha512-Mx4vCx7kBUwD8vGjQkt5e/Hj6DR+kKJhUc+fKkflc48vMN77drWR6AnbAuIVu+44BEsWJU2H0vm2oCAdzVAtQg==
+"@atlassian/forge-graphql@13.10.0":
+  version "13.10.0"
+  resolved "https://packages.atlassian.com/api/npm/atlassian-npm/@atlassian/forge-graphql/-/forge-graphql-13.10.0.tgz#14171310fa04480ea97bcda613e1c784ded29aa3"
+  integrity sha512-F/4EQsZ+DFmM1X8MkFr1QNyvUHGKMXMx4PQiYcpRL3xJTt0X5a1GMl+lbp0Y+ZlelwrrjRMwJX6dX3JQMjAQPQ==
   dependencies:
     "@forge/api" "^2.21.0"
     fs "^0.0.1-security"


### PR DESCRIPTION
# Description

I moved the selected repos message to the bottom in line with the “Load More” and “Select/Cancel” buttons. I adjusted the height of the table to 65vh (not 70vh) since the header “Select repositories” is slightly bigger than how it is for the Bitbucket import page.

Demo: https://www.loom.com/share/fa31cbfed1144b6180fc7d6068318312?sid=6819833e-dc33-49dc-ae08-d8b41dd21bb7

# Checklist

Please ensure that each of these items has been addressed:

- [X] I have tested these changes in my local environment
- [X] I have added/modified tests as applicable to cover these changes
- [X] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links