### PR TITLE
Setup Gitlab Maintainer Token FF

### DIFF
--- a/src/features.ts
+++ b/src/features.ts
@@ -2,6 +2,7 @@ export enum GitlabFeaturesEnum {
   SEND_STAGING_EVENTS = 'isSendStagingEventsEnabled',
   DATA_COMPONENT_TYPES = 'isDataComponentTypesEnabled',
   DISABLE_DOCUMENT_COMPONENT_LINKS = 'isDocumentComponentLinksDisabled',
+  ENABLE_GITLAB_MAINTAINER_TOKEN = 'isGitlabMaintainerTokenEnabled',
 }
 
 export type FeaturesList = { [key in GitlabFeaturesEnum]: boolean };

--- a/src/services/feature-flags.ts
+++ b/src/services/feature-flags.ts
@@ -11,10 +11,15 @@ const isDocumentComponentLinksDisabled = (defaultValue = false): boolean => {
   return process.env.DISABLE_DOCUMENT_COMPONENT_LINKS === 'true' || defaultValue;
 };
 
+const isGitlabMaintainerTokenEnabled = (defaultValue = false): boolean => {
+  return process.env.ENABLE_GITLAB_MAINTAINER_TOKEN === 'true' || defaultValue;
+};
+
 export const listFeatures = (): FeaturesList => {
   return {
     [GitlabFeaturesEnum.SEND_STAGING_EVENTS]: isSendStagingEventsEnabled(),
     [GitlabFeaturesEnum.DATA_COMPONENT_TYPES]: isDataComponentTypesEnabled(),
     [GitlabFeaturesEnum.DISABLE_DOCUMENT_COMPONENT_LINKS]: isDocumentComponentLinksDisabled(),
+    [GitlabFeaturesEnum.ENABLE_GITLAB_MAINTAINER_TOKEN]: isGitlabMaintainerTokenEnabled(),
   };
 };

--- a/src/utils/create-compass-yaml.test.ts
+++ b/src/utils/create-compass-yaml.test.ts
@@ -226,6 +226,7 @@ describe('formatLinks', () => {
       isDataComponentTypesEnabled: false,
       isSendStagingEventsEnabled: false,
       isDocumentComponentLinksDisabled: true,
+      isGitlabMaintainerTokenEnabled: false,
     });
 
     const result = formatLinks(inputLinks);
@@ -242,6 +243,7 @@ describe('formatLinks', () => {
       isDataComponentTypesEnabled: false,
       isSendStagingEventsEnabled: false,
       isDocumentComponentLinksDisabled: true,
+      isGitlabMaintainerTokenEnabled: false,
     });
 
     const result = formatLinks(null);
@@ -254,6 +256,7 @@ describe('formatLinks', () => {
       isDataComponentTypesEnabled: false,
       isSendStagingEventsEnabled: false,
       isDocumentComponentLinksDisabled: false,
+      isGitlabMaintainerTokenEnabled: false,
     });
 
     const result = formatLinks(inputLinks);

--- a/ui/src/hooks/useFeatures.ts
+++ b/ui/src/hooks/useFeatures.ts
@@ -8,6 +8,7 @@ export const useFeatures = (): [FeaturesList, boolean, ErrorTypes | undefined] =
     [GitlabFeaturesEnum.SEND_STAGING_EVENTS]: false,
     [GitlabFeaturesEnum.DATA_COMPONENT_TYPES]: false,
     [GitlabFeaturesEnum.DISABLE_DOCUMENT_COMPONENT_LINKS]: false,
+    [GitlabFeaturesEnum.ENABLE_GITLAB_MAINTAINER_TOKEN]: false,
   });
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<ErrorTypes>();


### PR DESCRIPTION
# Description

Sets up the base FF to be shared across branches for the gitlab maintainer token enablement work.

# Checklist

Please ensure that each of these items has been addressed:

- [x] I have tested these changes in my local environment
- [x] I have added/modified tests as applicable to cover these changes
- [x] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links