### PR TITLE
improving the error message when no app id variable

### DIFF
--- a/src/resolverTypes.ts
+++ b/src/resolverTypes.ts
@@ -10,6 +10,7 @@ import { FeaturesList } from './features';
 
 export enum DefaultErrorTypes {
   UNEXPECTED_ERROR = 'UNEXPECTED_ERROR',
+  NO_APP_ID_VARIABLE_DEFINED = 'NO_APP_ID_VARIABLE_DEFINED',
 }
 
 export enum AuthErrorTypes {

--- a/src/resolvers/shared-resolvers.ts
+++ b/src/resolvers/shared-resolvers.ts
@@ -59,7 +59,7 @@ export const appId = (): ResolverResponse<string> => {
   } catch (e) {
     return {
       success: false,
-      errors: [{ message: e.message, errorType: DefaultErrorTypes.UNEXPECTED_ERROR }],
+      errors: [{ message: e.message, errorType: DefaultErrorTypes.NO_APP_ID_VARIABLE_DEFINED }],
     };
   }
 };

--- a/ui/src/components/DefaultErrorState.test.tsx
+++ b/ui/src/components/DefaultErrorState.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { DefaultErrorTypes, ErrorTypes } from '../resolverTypes';
+import { ErrorMessages } from '../errorMessages';
+import { DefaultErrorState } from './DefaultErrorState';
+
+describe('DefaultErrorState', () => {
+  it('renders the correct message for NO_APP_ID_VARIABLE_DEFINED error type', () => {
+    const { getByTestId, getByText } = render(
+      <DefaultErrorState errorType={DefaultErrorTypes.NO_APP_ID_VARIABLE_DEFINED} />,
+    );
+
+    expect(getByTestId('no-appid-message')).toBeInTheDocument();
+    expect(getByText(ErrorMessages[DefaultErrorTypes.NO_APP_ID_VARIABLE_DEFINED].title)).toBeInTheDocument();
+    expect(getByText(ErrorMessages[DefaultErrorTypes.NO_APP_ID_VARIABLE_DEFINED].description)).toBeInTheDocument();
+  });
+
+  it('renders the default error message when no errorType is provided', () => {
+    render(<DefaultErrorState />);
+
+    expect(screen.getByTestId('error-state')).toBeInTheDocument();
+    expect(screen.getByText('Oops! Something went wrong.')).toBeInTheDocument();
+    expect(screen.getByText('Please, try to reload a page.')).toBeInTheDocument();
+  });
+
+  it('renders the errorType text when an unknown errorType is provided', () => {
+    const unknownErrorType = 'UNKNOWN_ERROR';
+    render(<DefaultErrorState errorType={unknownErrorType as any as ErrorTypes} />);
+
+    expect(screen.getByTestId('error-state')).toBeInTheDocument();
+    expect(screen.getByText('Oops! Something went wrong.')).toBeInTheDocument();
+    expect(screen.getByText(unknownErrorType)).toBeInTheDocument();
+    expect(screen.getByText('Please, try to reload a page.')).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/DefaultErrorState.tsx
+++ b/ui/src/components/DefaultErrorState.tsx
@@ -25,7 +25,7 @@ export const DefaultErrorState: FunctionComponent<Props> = ({ errorType }) => {
     default:
       return (
         <SectionWrapper data-testid='error-state'>
-          <SectionMessage title='Oopss! Something went wrong.' appearance='error'>
+          <SectionMessage title='Oops! Something went wrong.' appearance='error'>
             <ImportantText>{errorType}</ImportantText>
             <p>Please, try to reload a page.</p>
           </SectionMessage>

--- a/ui/src/components/DefaultErrorState.tsx
+++ b/ui/src/components/DefaultErrorState.tsx
@@ -3,19 +3,33 @@ import { FunctionComponent } from 'react';
 import SectionMessage from '@atlaskit/section-message';
 
 import { ImportantText, SectionWrapper } from './styles';
-import { ErrorTypes } from '../resolverTypes';
+import { DefaultErrorTypes, ErrorTypes } from '../resolverTypes';
+import { ErrorMessages } from '../errorMessages';
 
 type Props = {
   errorType?: ErrorTypes;
 };
 
 export const DefaultErrorState: FunctionComponent<Props> = ({ errorType }) => {
-  return (
-    <SectionWrapper data-testid='error-state'>
-      <SectionMessage title='Oops! Something went wrong.' appearance='error'>
-        <ImportantText>{errorType}</ImportantText>
-        <p>Please, try to reload a page.</p>
-      </SectionMessage>
-    </SectionWrapper>
-  );
+  switch (errorType) {
+    case DefaultErrorTypes.NO_APP_ID_VARIABLE_DEFINED:
+      return (
+        <SectionMessage
+          testId='no-appid-message'
+          appearance='error'
+          title={ErrorMessages[DefaultErrorTypes.NO_APP_ID_VARIABLE_DEFINED].title}
+        >
+          <p>{ErrorMessages[DefaultErrorTypes.NO_APP_ID_VARIABLE_DEFINED].description}</p>
+        </SectionMessage>
+      );
+    default:
+      return (
+        <SectionWrapper data-testid='error-state'>
+          <SectionMessage title='Oopss! Something went wrong.' appearance='error'>
+            <ImportantText>{errorType}</ImportantText>
+            <p>Please, try to reload a page.</p>
+          </SectionMessage>
+        </SectionWrapper>
+      );
+  }
 };

--- a/ui/src/context/AppContext.tsx
+++ b/ui/src/context/AppContext.tsx
@@ -26,8 +26,8 @@ export type AppContextProps = {
 export const AppContext = createContext({} as AppContextProps);
 
 export const AppContextProvider: FunctionComponent<AppContextProviderProps> = ({ children }) => {
-  const [isGroupsLoading, setGroupsLoading] = useState<boolean>(false);
-  const [isAppIdLoading, setAppIdLoading] = useState<boolean>(false);
+  const [isGroupsLoading, setIsGroupsLoading] = useState<boolean>(false);
+  const [isAppIdLoading, setIsAppIdLoading] = useState<boolean>(false);
   const [groups, setGroups] = useState<GitlabAPIGroup[]>();
   const [errorType, setErrorType] = useState<ErrorTypes>();
   const [initialRoute, setInitialRoute] = useState<ApplicationState>();
@@ -45,12 +45,12 @@ export const AppContextProvider: FunctionComponent<AppContextProviderProps> = ({
       console.error('Error while getting context', e);
     });
 
-    setGroupsLoading(true);
-    setAppIdLoading(true);
+    setIsGroupsLoading(true);
+    setIsAppIdLoading(true);
 
     getForgeAppId()
       .then(({ data, success, errors }) => {
-        setAppIdLoading(false);
+        setIsAppIdLoading(false);
 
         if (success && data) {
           setAppId(data);
@@ -61,13 +61,13 @@ export const AppContextProvider: FunctionComponent<AppContextProviderProps> = ({
         }
       })
       .catch(() => {
-        setAppIdLoading(false);
+        setIsAppIdLoading(false);
         setErrorType(AuthErrorTypes.UNEXPECTED_ERROR);
       });
 
     connectedInfo()
       .then(({ data, success, errors }) => {
-        setGroupsLoading(false);
+        setIsGroupsLoading(false);
 
         if (success && data && data.length > 0) {
           setGroups(data);
@@ -82,7 +82,7 @@ export const AppContextProvider: FunctionComponent<AppContextProviderProps> = ({
         setInitialRoute(ApplicationState.AUTH);
       })
       .catch(() => {
-        setGroupsLoading(false);
+        setIsGroupsLoading(false);
         setErrorType(AuthErrorTypes.UNEXPECTED_ERROR);
       });
   }, []);

--- a/ui/src/errorMessages.ts
+++ b/ui/src/errorMessages.ts
@@ -1,4 +1,4 @@
-import { AuthErrorTypes } from './resolverTypes';
+import { AuthErrorTypes, DefaultErrorTypes } from './resolverTypes';
 
 export const ErrorMessages = {
   [AuthErrorTypes.INVALID_GROUP_TOKEN]: {
@@ -13,6 +13,11 @@ export const ErrorMessages = {
     title: 'Group access token name is incorrect',
     description:
       'We couldn’t find a group access token with the name you entered. Check that the token name is correct and matches the token name in GitLab.',
+  },
+  [DefaultErrorTypes.NO_APP_ID_VARIABLE_DEFINED]: {
+    title: 'App ID variable is not defined',
+    description:
+      'Hello forge app developer! Check the README, but in your CLI, run forge variables set FORGE_APP_ID <ID from manifest, the part after ari:cloud:ecosystem::app/>',
   },
   [AuthErrorTypes.INCORRECT_GROUP_TOKEN_SCOPES]: {
     title: 'Group access token has incorrect scopes',


### PR DESCRIPTION
# Description

Adding a better error to the UI when the app id is not set. This should only impact developers since the official apps will always already have it set.


![Screenshot 2024-12-10 at 5 02 02 PM](https://github.com/user-attachments/assets/eb936bc9-24e7-48ed-942e-bc4396de63da)

# Checklist
Please ensure that each of these items has been addressed:

- [X] I have tested these changes in my local environment
- [X] I have added/modified tests as applicable to cover these changes
- [X] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links