### PR TITLE
Pull getImportResult to shared resolver

### DIFF
--- a/src/resolvers/admin-resolvers.ts
+++ b/src/resolvers/admin-resolvers.ts
@@ -1,15 +1,21 @@
 import Resolver from '@forge/resolver';
 
-import graphqlGateway, { CompassComponentTypeObject } from '@atlassian/forge-graphql';
-import { getGroupProjects } from '../services/fetch-projects';
-import { AuthErrorTypes, GitlabAPIGroup, ResolverResponse, DefaultErrorTypes, FeaturesList } from '../resolverTypes';
+import graphqlGateway from '@atlassian/forge-graphql';
+import {
+  AuthErrorTypes,
+  GitlabAPIGroup,
+  ResolverResponse,
+  DefaultErrorTypes,
+  FeaturesList,
+  ProjectImportResult,
+} from '../resolverTypes';
 import { connectGroup, InvalidGroupTokenError } from '../services/group';
 
 import { setupAndValidateWebhook } from '../services/webhooks';
 import { disconnectGroup } from '../services/disconnect-group';
 import { getForgeAppId } from '../utils/get-forge-app-id';
 import { getLastSyncTime } from '../services/last-sync-time';
-import { appId, connectedGroupsInfo, getFeatures, groupsAllExisting } from './shared-resolvers';
+import { appId, connectedGroupsInfo, getFeatures, getImportResult, groupsAllExisting } from './shared-resolvers';
 
 const resolver = new Resolver();
 
@@ -91,6 +97,18 @@ resolver.define('features', (): ResolverResponse<FeaturesList> => {
 
 resolver.define('appId', (): ResolverResponse<string> => {
   return appId();
+});
+
+resolver.define('project/import/result', async (): Promise<ResolverResponse<ProjectImportResult>> => {
+  try {
+    const importResult = await getImportResult();
+    return { success: true, data: importResult };
+  } catch (e) {
+    return {
+      success: false,
+      errors: [{ message: e.message, errorType: e.errorType }],
+    };
+  }
 });
 
 export default resolver.getDefinitions();

--- a/src/resolvers/import-resolvers.ts
+++ b/src/resolvers/import-resolvers.ts
@@ -10,16 +10,17 @@ import {
   ImportStatus,
   FeaturesList,
 } from '../resolverTypes';
-import {
-  clearImportResult,
-  getImportResult,
-  getImportStatus,
-  ImportFailedError,
-  importProjects,
-} from '../services/import-projects';
+import { clearImportResult, getImportStatus, importProjects } from '../services/import-projects';
 import { GroupProjectsResponse, TeamsWithMembershipStatus } from '../types';
 import { getAllComponentTypeIds } from '../client/compass';
-import { appId, connectedGroupsInfo, getFeatures, groupsAllExisting } from './shared-resolvers';
+import {
+  appId,
+  connectedGroupsInfo,
+  getFeatures,
+  getImportResult,
+  groupsAllExisting,
+  ImportFailedError,
+} from './shared-resolvers';
 import { getFirstPageOfTeamsWithMembershipStatus } from '../services/get-teams';
 import { getTeamOnboarding, setTeamOnboarding } from '../services/onboarding';
 

--- a/src/services/import-projects.test.ts
+++ b/src/services/import-projects.test.ts
@@ -7,7 +7,6 @@ mockForgeApi();
 import { Queue } from '@forge/events';
 import { storage } from '@forge/api';
 import {
-  ImportFailedError,
   importProjects,
   clearImportResult,
   getImportResult,
@@ -18,6 +17,7 @@ import { setLastSyncTime } from './last-sync-time';
 import { mocked } from 'jest-mock';
 import { ImportErrorTypes } from '../resolverTypes';
 import { ALL_SETTLED_STATUS, getFormattedErrors } from '../utils/promise-allsettled-helpers';
+import { ImportFailedError } from '../resolvers/shared-resolvers';
 
 const storageGetSuccess = jest.fn().mockReturnValue(['jobId1', 'jobId2']);
 const storageGetEmptyArray = jest.fn().mockReturnValue([]);


### PR DESCRIPTION
# Description

Pulls out the resolver for getImportResult to shared so that it can be used as an admin resolver as well. Fixes the following issue thrown on the connected state page.

```
Error: Resolver has no definition for 'project/import/result'.
    at Resolver.getFunction (webpack://insert-name-here/node_modules/@forge/resolver/out/index.js:47:1)
    at Object.resolve (webpack://insert-name-here/node_modules/@forge/resolver/out/index.js:54:1)
    at /private/var/folders/l2/_4qylv252d30v7kqnbtrlb6r0000gn/T/forge-dist-31080-DgA5Wpb2Kupm/__forge_wrapper__.cjs:2:583386
    at w (/private/var/folders/l2/_4qylv252d30v7kqnbtrlb6r0000gn/T/forge-dist-31080-DgA5Wpb2Kupm/__forge_wrapper__.cjs:2:583392)
    at new Promise (<anonymous>)
    at /private/var/folders/l2/_4qylv252d30v7kqnbtrlb6r0000gn/T/forge-dist-31080-DgA5Wpb2Kupm/__forge_wrapper__.cjs:2:583149
    at AsyncLocalStorage.run (node:async_hooks:346:14)
    at r.<computed> (/private/var/folders/l2/_4qylv252d30v7kqnbtrlb6r0000gn/T/forge-dist-31080-DgA5Wpb2Kupm/__forge_wrapper__.cjs:2:582082)
    at process.<anonymous> (/Users/svenkateswaran/.nvm/versions/node/v20.14.0/lib/node_modules/@forge/cli/node_modules/@forge/tunnel/out/sandbox/sandbox-runner.js:7:26)
    at process.emit (node:events:519:28)
```

# Checklist

Please ensure that each of these items has been addressed:

- [x] I have tested these changes in my local environment
- [ ] I have added/modified tests as applicable to cover these changes
- [ ] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links