### PR TITLE
Add support for feature flagging using cloudIds when available

### DIFF
--- a/src/resolvers/admin-resolvers.ts
+++ b/src/resolvers/admin-resolvers.ts
@@ -129,8 +129,12 @@ resolver.define('project/lastSyncTime', async (): Promise<ResolverResponse<strin
   }
 });
 
-resolver.define('features', (): ResolverResponse<FeaturesList> => {
-  return getFeatures();
+resolver.define('features', (req): ResolverResponse<FeaturesList> => {
+  const {
+    context: { cloudId },
+  } = req;
+
+  return getFeatures(cloudId);
 });
 
 resolver.define('appId', (): ResolverResponse<string> => {

--- a/src/resolvers/import-resolvers.ts
+++ b/src/resolvers/import-resolvers.ts
@@ -121,8 +121,12 @@ resolver.define('project/import/clear', async (): Promise<ResolverResponse> => {
   }
 });
 
-resolver.define('features', (): ResolverResponse<FeaturesList> => {
-  return getFeatures();
+resolver.define('features', (req): ResolverResponse<FeaturesList> => {
+  const {
+    context: { cloudId },
+  } = req;
+
+  return getFeatures(cloudId);
 });
 
 resolver.define('appId', (): ResolverResponse<string> => {

--- a/src/resolvers/shared-resolvers.ts
+++ b/src/resolvers/shared-resolvers.ts
@@ -5,9 +5,9 @@ import { getWebhookSetupConfig, setupAndValidateWebhook } from '../services/webh
 import { getForgeAppId } from '../utils/get-forge-app-id';
 import { WebhookSetupConfig } from '../types';
 
-export const getFeatures = (): ResolverResponse<FeaturesList> => {
+export const getFeatures = (cloudId: string): ResolverResponse<FeaturesList> => {
   try {
-    const features = listFeatures();
+    const features = listFeatures(cloudId);
     return {
       success: true,
       data: features,

--- a/src/services/feature-flags.test.ts
+++ b/src/services/feature-flags.test.ts
@@ -5,7 +5,7 @@ describe('listFeatures', () => {
     process.env.FF_SEND_STAGING_EVENTS = 'false';
   });
 
-  test('gets feature flags from their variables', async () => {
+  it('gets feature flags from their variables', async () => {
     process.env.FF_SEND_STAGING_EVENTS = 'true';
 
     const featureFlags = listFeatures();
@@ -13,9 +13,28 @@ describe('listFeatures', () => {
     expect(featureFlags.isSendStagingEventsEnabled).toEqual(true);
   });
 
-  test('gets feature flags in their default state', async () => {
+  it('gets feature flags in their default state', async () => {
     const featureFlags = listFeatures();
 
     expect(featureFlags.isSendStagingEventsEnabled).toEqual(false);
+  });
+
+  it('uses cloudId to determine if gitlab maintainer token is enabled', async () => {
+    process.env.ENABLE_GITLAB_MAINTAINER_TOKEN_CLOUD_IDS = 'cloudId1,cloudId2';
+    process.env.ENABLE_GITLAB_MAINTAINER_TOKEN = 'true';
+
+    let featureFlags = listFeatures('cloudId1');
+    expect(featureFlags.isGitlabMaintainerTokenEnabled).toEqual(true);
+
+    featureFlags = listFeatures();
+    expect(featureFlags.isGitlabMaintainerTokenEnabled).toEqual(true);
+
+    featureFlags = listFeatures('cloudId3');
+    expect(featureFlags.isGitlabMaintainerTokenEnabled).toEqual(false);
+
+    process.env.ENABLE_GITLAB_MAINTAINER_TOKEN_CLOUD_IDS = '';
+
+    featureFlags = listFeatures('cloudId1');
+    expect(featureFlags.isGitlabMaintainerTokenEnabled).toEqual(true);
   });
 });

--- a/src/services/feature-flags.ts
+++ b/src/services/feature-flags.ts
@@ -11,15 +11,22 @@ const isDocumentComponentLinksDisabled = (defaultValue = false): boolean => {
   return process.env.DISABLE_DOCUMENT_COMPONENT_LINKS === 'true' || defaultValue;
 };
 
-export const isGitlabMaintainerTokenEnabled = (defaultValue = false): boolean => {
-  return process.env.ENABLE_GITLAB_MAINTAINER_TOKEN === 'true' || defaultValue;
+export const isGitlabMaintainerTokenEnabled = (cloudId?: string, defaultValue = false): boolean => {
+  // cloudId is available in frontend context when fetching features for AppContext.
+  // It is not available in all backend contexts, so we will use the default value if it is not provided.
+  const isEnabledForCloudId =
+    !!cloudId && !!process.env.ENABLE_GITLAB_MAINTAINER_TOKEN_CLOUD_IDS
+      ? process.env.ENABLE_GITLAB_MAINTAINER_TOKEN_CLOUD_IDS.split(',').includes(cloudId)
+      : true;
+
+  return (process.env.ENABLE_GITLAB_MAINTAINER_TOKEN === 'true' && isEnabledForCloudId) || defaultValue;
 };
 
-export const listFeatures = (): FeaturesList => {
+export const listFeatures = (cloudId?: string): FeaturesList => {
   return {
     [GitlabFeaturesEnum.SEND_STAGING_EVENTS]: isSendStagingEventsEnabled(),
     [GitlabFeaturesEnum.DATA_COMPONENT_TYPES]: isDataComponentTypesEnabled(),
     [GitlabFeaturesEnum.DISABLE_DOCUMENT_COMPONENT_LINKS]: isDocumentComponentLinksDisabled(),
-    [GitlabFeaturesEnum.ENABLE_GITLAB_MAINTAINER_TOKEN]: isGitlabMaintainerTokenEnabled(),
+    [GitlabFeaturesEnum.ENABLE_GITLAB_MAINTAINER_TOKEN]: isGitlabMaintainerTokenEnabled(cloudId),
   };
 };


### PR DESCRIPTION
# Description

Includes optionality to use cloudIds in feature flagging context when available. The FF fetch for UI goes through admin-resolvers which have access to cloudIds. Direct usage of the flags from backend would circumvent these checks and rely on global FF flag result. 

Tested the changes by setting FF vars from my local and verifying flag evaluation.

# Checklist

Please ensure that each of these items has been addressed:

- [x] I have tested these changes in my local environment
- [ ] I have added/modified tests as applicable to cover these changes
- [ ] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links