### PR TITLE
add type duplication to build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Set up the Custom UI Frontend
     # in a new tab
     yarn ui:install
    
-    # build the frontend 
+    # build the frontend. This will also duplicate several types files that are needed in the forge backend and ui, overwriting the versions in the ui
     yarn ui:build
     
     # watch the frontend

--- a/manifest.yml
+++ b/manifest.yml
@@ -64,7 +64,7 @@ modules:
         function: import-projects
         method: import
 app:
-  id: ari:cloud:ecosystem::app/e04e572c-d275-4782-95a5-b2084dda4e5f
+  id: ari:cloud:ecosystem::app/60787eba-aec5-49b4-979d-db8e77de32db
   runtime:
     name: nodejs18.x
   features:

--- a/manifest.yml
+++ b/manifest.yml
@@ -64,7 +64,7 @@ modules:
         function: import-projects
         method: import
 app:
-  id: ari:cloud:ecosystem::app/60787eba-aec5-49b4-979d-db8e77de32db
+  id: ari:cloud:ecosystem::app/e04e572c-d275-4782-95a5-b2084dda4e5f
   runtime:
     name: nodejs18.x
   features:

--- a/src/features.ts
+++ b/src/features.ts
@@ -1,3 +1,9 @@
+/*
+  TO EDIT THIS FILE, you must edit the file in the repo's src directory and running yarn ui:build or yarn ui:prebuild will generate the types in the ui/src directory.
+
+  This file contains types that are used in both of the directories and need to stay in sync. So, the ui/src types are gitignored
+ */
+
 export enum GitlabFeaturesEnum {
   SEND_STAGING_EVENTS = 'isSendStagingEventsEnabled',
   DATA_COMPONENT_TYPES = 'isDataComponentTypesEnabled',

--- a/src/resolverTypes.ts
+++ b/src/resolverTypes.ts
@@ -8,6 +8,12 @@ import {
 } from './types';
 import { FeaturesList } from './features';
 
+/*
+  TO EDIT THIS FILE, you must edit the file in the repo's src directory and running yarn ui:build or yarn ui:prebuild will generate the types in the ui/src directory.
+
+  This file contains types that are used in both of the directories and need to stay in sync. So, the ui/src types are gitignored
+ */
+
 export enum DefaultErrorTypes {
   UNEXPECTED_ERROR = 'UNEXPECTED_ERROR',
   NO_APP_ID_VARIABLE_DEFINED = 'NO_APP_ID_VARIABLE_DEFINED',

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,12 @@ import {
   DataProviderDeploymentEvent,
 } from '@atlassian/forge-graphql';
 
+/*
+  TO EDIT THIS FILE, you must edit the file in the repo's src directory and running yarn ui:build or yarn ui:prebuild will generate the types in the ui/src directory.
+
+  This file contains types that are used in both of the directories and need to stay in sync. So, the ui/src types are gitignored
+ */
+
 type WebtriggerRequest = {
   body: string;
   queryParameters: {

--- a/ui/package.json
+++ b/ui/package.json
@@ -49,7 +49,7 @@
   },
   "scripts": {
     "start": "SKIP_PREFLIGHT_CHECK=true BROWSER=none PORT=3001 react-scripts start",
-    "build": "SKIP_PREFLIGHT_CHECK=true react-scripts build",
+    "build": "yarn prebuild && SKIP_PREFLIGHT_CHECK=true react-scripts build",
     "test": "SKIP_PREFLIGHT_CHECK=true react-scripts test",
     "pretest": "node -p \"JSON.stringify({...require('@forge/bridge/package.json'), main: 'out/index.js'}, null, 2)\" > tmp.json && mv tmp.json node_modules/@forge/bridge/package.json",
     "eject": "react-scripts eject",


### PR DESCRIPTION
# Description

Making local dev loop smoother for Gitlab app with generating the types file on build, and clarifying to contributors which file to edit.

# Checklist

Please ensure that each of these items has been addressed:

- [X] I have tested these changes in my local environment
- [ ] I have added/modified tests as applicable to cover these changes
- [ ] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links