### PR TITLE
Add pagination for group fetches and enhance logging

### DIFF
--- a/src/client/gitlab.ts
+++ b/src/client/gitlab.ts
@@ -82,6 +82,8 @@ export const callGitlab = async (
     body,
   });
 
+  console.log(`Gitlab response status: ${resp.status}`);
+
   if (resp.status === 204) {
     // no content, we can just return here
     return null;
@@ -105,20 +107,20 @@ export const getGroupsData = async (
   owned?: string,
   minAccessLevel?: number,
   name?: string,
+  pageSize = 100,
 ): Promise<GitlabAPIGroup[]> => {
   const params = {
     ...(owned ? { owned } : {}),
     ...(minAccessLevel ? { min_access_level: minAccessLevel.toString() } : {}),
     ...(name ? { search: name } : {}),
+    ...(pageSize ? { per_page: pageSize.toString() } : {}),
   };
 
   const queryParams = queryParamsGenerator(params);
 
-  const { data } = await callGitlab(
-    `getGroupsData - Query params: ${queryParams}`,
-    `/api/v4/groups?${queryParams}`,
-    groupAccessToken,
-  );
+  const { data } = await callGitlab(`getGroupsData`, `/api/v4/groups?${queryParams}`, groupAccessToken);
+
+  console.log('Number of groups fetched:', data.length);
 
   return data;
 };

--- a/src/resolvers/shared-resolvers.ts
+++ b/src/resolvers/shared-resolvers.ts
@@ -43,6 +43,7 @@ export const groupsAllExisting = async (): Promise<ResolverResponse<GitlabAPIGro
 };
 
 export const connectedGroupsInfo = async (): Promise<ResolverResponse<GitlabAPIGroup[]>> => {
+  console.log('Fetching connected groups info');
   try {
     const connectedGroups = await getConnectedGroups();
     const setupConfig = await getWebhookSetupConfig();
@@ -53,6 +54,7 @@ export const connectedGroupsInfo = async (): Promise<ResolverResponse<GitlabAPIG
 
     return { success: true, data: connectedGroups };
   } catch (e) {
+    console.log('Error fetching connected groups info', e);
     return {
       success: false,
       errors: [{ message: 'Get connected groups failed.', errorType: AuthErrorTypes.UNEXPECTED_ERROR }],
@@ -76,6 +78,7 @@ export const appId = (): ResolverResponse<string> => {
 };
 
 export const webhookSetupConfig = async (): Promise<ResolverResponse<WebhookSetupConfig>> => {
+  console.log('Fetching webhook setup config');
   try {
     const config = await getWebhookSetupConfig();
     return {
@@ -83,6 +86,7 @@ export const webhookSetupConfig = async (): Promise<ResolverResponse<WebhookSetu
       data: config,
     };
   } catch (e) {
+    console.log('Error fetching webhook setup config', e);
     return {
       success: false,
       errors: [{ message: e.message, errorType: DefaultErrorTypes.UNEXPECTED_ERROR }],

--- a/src/services/group.ts
+++ b/src/services/group.ts
@@ -51,8 +51,10 @@ export const connectGroupAsMaintainer = async (token: string, groupName: string)
 
   let groups: GitlabAPIGroup[];
   try {
+    console.log('Fetching groups data for Maintainer token role');
     groups = await getGroupsData(token, null, null, groupName);
   } catch (e) {
+    console.log('Error fetching groups data for Maintainer token role');
     throw new InvalidGroupTokenError(AuthErrorTypes.INVALID_GROUP_TOKEN);
   }
 
@@ -79,6 +81,7 @@ export const connectGroupAsOwner = async (
   let groupId;
   let groupName;
   try {
+    console.log('Fetching groups data for Owner token role');
     const [group] = await getGroupsData(token, 'true');
     ({ id: groupId, name: groupName } = group);
   } catch (e) {

--- a/src/services/webhooks.ts
+++ b/src/services/webhooks.ts
@@ -173,7 +173,9 @@ export const getWebhookSetupConfig = async (): Promise<WebhookSetupConfig> => {
   const groupsResult = await Promise.allSettled(groups.map((group: Result) => storage.get(group.key)));
 
   if (hasRejections(groupsResult)) {
-    throw new Error(`Error getting groupIds with in-progress webhooks setup: ${getFormattedErrors(groupsResult)}`);
+    const errorMsg = `Error getting groupIds with in-progress webhooks setup: ${getFormattedErrors(groupsResult)}`;
+    console.log(errorMsg);
+    throw new Error(errorMsg);
   }
 
   const groupIds = groupsResult.map((groupResult: PromiseFulfilledResult<number>) => groupResult.value);


### PR DESCRIPTION
# Description

Default page sizes for groups data fetch is 20, increasing this to 100. Further enhanced logging through out resolvers used in the initial configuration for better debugging. Dropped a query param log containing UGC.

# Checklist

Please ensure that each of these items has been addressed:

- [ ] I have tested these changes in my local environment
- [ ] I have added/modified tests as applicable to cover these changes
- [ ] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links