### PR TITLE
Added logic for gitlab auto-import

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -38,7 +38,7 @@ modules:
     - key: pre-uninstall-ep
       function: pre-uninstall
   # This module is currently experimental and unpublished.
-  # Contact the Compass team if interested in building an app using this modu
+  # Contact the Compass team if interested in building an app using this module.
   compass:importRecentRepos:
     - key: import-recent-repos
       function: import-recent-repos-fn

--- a/src/client/gitlab.ts
+++ b/src/client/gitlab.ts
@@ -229,11 +229,13 @@ export const getProjects = async (
   page: number,
   perPage: number,
   search?: string,
+  orderBy?: string,
 ): Promise<{ data: GitlabAPIProject[]; headers: Headers }> => {
   const params = {
     include_subgroups: 'true',
     page: page.toString(),
     per_page: perPage.toString(),
+    ...(orderBy ? { order_by: orderBy } : {}),
     ...(search ? { search } : {}),
   };
 

--- a/src/entry/import-recent-repos/index.ts
+++ b/src/entry/import-recent-repos/index.ts
@@ -1,20 +1,168 @@
-import { ImportRecentReposPayload, ImportRecentReposReturn } from './types';
+import { internalMetrics } from '@forge/metrics';
+import { backOff } from 'exponential-backoff';
+import { storage } from '@forge/api';
+import { ALL_SETTLED_STATUS } from '@atlassian/forge-graphql';
+import { createComponent } from '../../client/compass';
+import { getConnectedGroups } from '../../services/group';
+import { getProjectLabels } from '../../services/get-labels';
+import { ImportRecentReposPayload, ImportRecentReposReturn, ImportResultsSummary } from './types';
+import { BACK_OFF, DEFAULT_COMPONENT_TYPE_ID, STORAGE_KEYS, STORAGE_SECRETS } from '../../constants';
+import { CompareProjectWithExistingComponent, GitlabAPIProject, ImportableProject } from '../../types';
+import { getProjects } from '../../client/gitlab';
+import { compareProjectWithExistingComponent } from '../../services/fetch-projects';
 
-/**
- * Dummy handler function to import recent repositories.
- *
- * @param payload - The payload containing the number of recent repositories to import.
- * @returns An object indicating the success of the operation and the number of repositories imported.
- */
+const fetchRecentProjects = async (
+  groupToken: string,
+  groupId: number,
+  numRepos: number,
+): Promise<{ data: GitlabAPIProject[]; headers: Headers }> => {
+  return getProjects(groupToken, groupId, 1, numRepos, undefined, 'last_activity_at');
+};
+
+const checkForExistingImports = async (
+  cloudId: string,
+  groupToken: string,
+  projects: GitlabAPIProject[],
+): Promise<CompareProjectWithExistingComponent[]> => {
+  const settledPromises = await Promise.allSettled(
+    projects.map((project) => compareProjectWithExistingComponent(cloudId, project.id, groupToken)),
+  );
+
+  const checkedDataWithExistingComponents = settledPromises.map((result) => {
+    if (result.status === ALL_SETTLED_STATUS.FULFILLED) {
+      return result.value;
+    }
+    console.error(`Error processing project: ${result.reason}`);
+    throw new Error(result.reason);
+  });
+
+  return checkedDataWithExistingComponents;
+};
+
+const filterExistingProjects = (
+  projects: GitlabAPIProject[],
+  checkedDataWithExistingComponents: CompareProjectWithExistingComponent[],
+): GitlabAPIProject[] => {
+  return projects
+    .filter((project, i) => !checkedDataWithExistingComponents[i].hasComponent)
+    .map((project, i) => ({
+      ...project,
+      ...checkedDataWithExistingComponents[i],
+    }));
+};
+
+const mapProjectToImportableProject = async (
+  project: GitlabAPIProject,
+  groupToken: string,
+): Promise<ImportableProject> => {
+  return {
+    id: project.id,
+    name: project.name,
+    description: project.description,
+    url: project.web_url,
+    defaultBranch: project.default_branch,
+    groupName: project.namespace.name,
+    groupPath: project.namespace.path,
+    groupFullPath: project.namespace.full_path,
+    labels: await getProjectLabels(project.id, groupToken, project.topics),
+    isManaged: false,
+    hasComponent: false,
+    isCompassFilePrOpened: false,
+    typeId: DEFAULT_COMPONENT_TYPE_ID,
+  };
+};
+
+const setFailedRepositoriesToStore = async (project: ImportableProject) => {
+  try {
+    internalMetrics.counter('compass.gitlab.import.end.fail').incr();
+    await backOff(
+      () => storage.set(`${STORAGE_KEYS.CURRENT_IMPORT_FAILED_PROJECT_PREFIX}:${project.id}`, project),
+      BACK_OFF,
+    );
+  } catch (err) {
+    console.error('Failed to stored failed project after all retries', err);
+  }
+};
+
+const importReposToCompass = async (
+  cloudId: string,
+  projects: GitlabAPIProject[],
+  groupToken: string,
+): Promise<PromiseSettledResult<boolean>[]> => {
+  return Promise.allSettled(
+    projects.map(async (project) => {
+      const projectReadyForImport = await mapProjectToImportableProject(project, groupToken);
+      try {
+        const response = await backOff(() => createComponent(cloudId, projectReadyForImport), BACK_OFF);
+        if ('err' in response) {
+          await setFailedRepositoriesToStore(projectReadyForImport);
+          return false;
+        }
+        internalMetrics.counter('compass.gitlab.import.end.success').incr();
+        return true;
+      } catch (err) {
+        console.error(`Failed to import project ${project.id}`, err);
+        await setFailedRepositoriesToStore(projectReadyForImport);
+        return false;
+      }
+    }),
+  );
+};
+
+const summarizeImportResults = (importResults: PromiseSettledResult<boolean>[]): ImportResultsSummary => {
+  return importResults.reduce(
+    (acc, result) => {
+      if (result.status === 'fulfilled') {
+        acc[result.value ? 'successfulImports' : 'failedImports'] += 1;
+      }
+      return acc;
+    },
+    { successfulImports: 0, failedImports: 0 },
+  );
+};
+
 export const importRecentRepos = async ({
+  cloudId,
   numRepos = 20,
 }: ImportRecentReposPayload): Promise<ImportRecentReposReturn> => {
-  console.log(`Importing ${numRepos} recent repos`);
+  try {
+    const connectedGroups = await getConnectedGroups(); // only groups where you are the owner, not maintainer
 
-  return {
-    success: true,
-    response: {
-      numReposImported: numRepos,
-    },
-  };
+    if (!connectedGroups || connectedGroups.length === 0) {
+      console.error('No connected Gitlab groups found.');
+      return {
+        success: false,
+        errors: 'No connected Gitlab groups',
+        response: { numReposImported: 0 },
+      };
+    }
+
+    const groupId = connectedGroups[0].id;
+    const groupToken = await storage.getSecret(`${STORAGE_SECRETS.GROUP_TOKEN_KEY_PREFIX}${groupId}`);
+
+    const recentProjects = await fetchRecentProjects(groupToken, groupId, numRepos);
+    const checkedDataWithExistingComponents = await checkForExistingImports(cloudId, groupToken, recentProjects.data);
+    const projectsToImport = filterExistingProjects(recentProjects.data, checkedDataWithExistingComponents);
+
+    console.log(`Importing ${projectsToImport.length} recent repos that have not been imported yet`);
+
+    const importResults = await importReposToCompass(cloudId, projectsToImport, groupToken);
+    const { successfulImports, failedImports } = summarizeImportResults(importResults);
+
+    return {
+      success: failedImports === 0,
+      response: {
+        numReposImported: successfulImports,
+      },
+    };
+  } catch (error) {
+    console.error('An error occurred during the import process:', error);
+    return {
+      success: false,
+      errors: `An error occurred while importing projects: ${error.message}`,
+      response: {
+        numReposImported: 0,
+      },
+    };
+  }
 };

--- a/src/entry/import-recent-repos/index.ts
+++ b/src/entry/import-recent-repos/index.ts
@@ -126,7 +126,7 @@ export const importRecentRepos = async ({
   numRepos = 20,
 }: ImportRecentReposPayload): Promise<ImportRecentReposReturn> => {
   try {
-    const connectedGroups = await getConnectedGroups(); // only groups where you are the owner, not maintainer
+    const connectedGroups = await getConnectedGroups();
 
     if (!connectedGroups || connectedGroups.length === 0) {
       console.error('No connected Gitlab groups found.');

--- a/src/entry/import-recent-repos/test.ts
+++ b/src/entry/import-recent-repos/test.ts
@@ -1,0 +1,311 @@
+/* eslint-disable import/first */
+import { Component } from '@atlassian/forge-graphql/dist/src/compound-types';
+import { internalMetrics } from '@forge/metrics';
+import { mockForgeApi, storage } from '../../__tests__/helpers/forge-helper';
+
+mockForgeApi();
+import { importRecentRepos } from '../..';
+import { getProjects } from '../../client/gitlab';
+import { compareProjectWithExistingComponent } from '../../services/fetch-projects';
+import { createComponent } from '../../client/compass';
+import { GitlabAPIGroup, GitlabAPIProject } from '../../types';
+import { getConnectedGroups } from '../../services/group';
+
+// Mock the dependencies
+jest.mock('../../services/group');
+jest.mock('../../client/gitlab');
+jest.mock('../../services/fetch-projects');
+jest.mock('../../client/compass');
+
+const mockedIncr = jest.fn();
+jest.mock('@forge/metrics', () => ({
+  internalMetrics: {
+    counter: jest.fn(() => ({
+      incr: mockedIncr,
+    })),
+  },
+}));
+
+// Define mock implementations
+const mockStorageGet = jest.mocked(storage.getSecret);
+const mockCreateComponent = jest.mocked(createComponent);
+
+// Define constants and mock data
+const MOCK_GROUP_TOKEN = 'mock-group-token';
+const MOCK_CLOUD_ID = 'cloud-id';
+const MOCK_GROUP_ID_1 = 12345;
+
+const MOCK_CONNECTED_GROUP_1 = {
+  full_name: 'full name',
+  name: 'mock-group-name-1',
+  id: MOCK_GROUP_ID_1,
+  path: 'mock-group-path-1',
+} as GitlabAPIGroup;
+
+const MOCK_CONNECTED_GROUP_2 = {
+  full_name: 'full name',
+  name: 'mock-group-name-2',
+  id: MOCK_GROUP_ID_1,
+  path: 'mock-group-path-2',
+} as GitlabAPIGroup;
+
+const MOCK_THREE_PROJECTS = [
+  {
+    id: 1,
+    description: 'desc',
+    name: 'repo1',
+    topics: [],
+    default_branch: 'main',
+    web_url: 'url-1',
+    namespace: {
+      id: MOCK_GROUP_ID_1,
+      full_path: MOCK_CONNECTED_GROUP_1.path,
+      name: MOCK_CONNECTED_GROUP_1.name,
+      path: MOCK_CONNECTED_GROUP_1.path,
+    },
+    created_at: '2025-01-27',
+  },
+  {
+    id: 2,
+    description: 'desc',
+    name: 'repo2',
+    topics: [],
+    default_branch: 'main',
+    web_url: 'url-2',
+    namespace: {
+      id: MOCK_GROUP_ID_1,
+      full_path: MOCK_CONNECTED_GROUP_1.path,
+      name: MOCK_CONNECTED_GROUP_1.name,
+      path: MOCK_CONNECTED_GROUP_1.path,
+    },
+    created_at: '2025-01-27',
+  },
+  {
+    id: 3,
+    description: 'desc',
+    name: 'repo3',
+    topics: [],
+    default_branch: 'main',
+    web_url: 'url-3',
+    namespace: {
+      id: MOCK_GROUP_ID_1,
+      full_path: MOCK_CONNECTED_GROUP_1.path,
+      name: MOCK_CONNECTED_GROUP_1.name,
+    },
+    created_at: '2025-01-27',
+  },
+] as GitlabAPIProject[];
+
+describe('importRecentRepos module', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should import recent projects successfully with only one connected group', async () => {
+    (getConnectedGroups as jest.Mock).mockResolvedValue([MOCK_CONNECTED_GROUP_1]);
+    mockStorageGet.mockResolvedValue(MOCK_GROUP_TOKEN);
+
+    (getProjects as jest.Mock).mockResolvedValue({ data: MOCK_THREE_PROJECTS });
+    (compareProjectWithExistingComponent as jest.Mock).mockResolvedValue({ hasComponent: false });
+    mockCreateComponent.mockResolvedValueOnce({ id: 1, name: 'repo1' } as unknown as Component);
+    mockCreateComponent.mockResolvedValueOnce({ id: 2, name: 'repo2' } as unknown as Component);
+    mockCreateComponent.mockResolvedValueOnce({ id: 3, name: 'repo3' } as unknown as Component);
+
+    const result = await importRecentRepos({ cloudId: MOCK_CLOUD_ID, numRepos: 3 });
+    expect(getProjects).toHaveBeenCalledWith(MOCK_GROUP_TOKEN, MOCK_GROUP_ID_1, 1, 3, undefined, 'last_activity_at');
+
+    expect(mockCreateComponent).toHaveBeenCalledTimes(3);
+    expect(mockCreateComponent).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ name: 'repo1' }));
+    expect(mockCreateComponent).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ name: 'repo2' }));
+    expect(mockCreateComponent).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ name: 'repo3' }));
+
+    expect(internalMetrics.counter).toHaveBeenCalledTimes(3);
+    expect(internalMetrics.counter).toHaveBeenCalledWith('compass.gitlab.import.end.success');
+    expect(mockedIncr).toHaveBeenCalledTimes(3);
+
+    expect(result.success).toBe(true);
+    expect(result.response.numReposImported).toBe(3);
+  });
+
+  it('should import recent projects successfully with multiple connected groups', async () => {
+    (getConnectedGroups as jest.Mock).mockResolvedValue([MOCK_CONNECTED_GROUP_1, MOCK_CONNECTED_GROUP_2]);
+    mockStorageGet.mockResolvedValue(MOCK_GROUP_TOKEN);
+
+    (getProjects as jest.Mock).mockResolvedValue({ data: MOCK_THREE_PROJECTS });
+    (compareProjectWithExistingComponent as jest.Mock).mockResolvedValue({ hasComponent: false });
+    mockCreateComponent.mockResolvedValueOnce({ id: 1, name: 'repo1' } as unknown as Component);
+    mockCreateComponent.mockResolvedValueOnce({ id: 2, name: 'repo2' } as unknown as Component);
+    mockCreateComponent.mockResolvedValueOnce({ id: 3, name: 'repo3' } as unknown as Component);
+
+    const result = await importRecentRepos({ cloudId: MOCK_CLOUD_ID, numRepos: 3 });
+    expect(getProjects).toHaveBeenCalledWith(MOCK_GROUP_TOKEN, MOCK_GROUP_ID_1, 1, 3, undefined, 'last_activity_at');
+
+    expect(mockCreateComponent).toHaveBeenCalledTimes(3);
+    expect(mockCreateComponent).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ name: 'repo1' }));
+    expect(mockCreateComponent).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ name: 'repo2' }));
+    expect(mockCreateComponent).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ name: 'repo3' }));
+
+    expect(internalMetrics.counter).toHaveBeenCalledTimes(3);
+    expect(internalMetrics.counter).toHaveBeenCalledWith('compass.gitlab.import.end.success');
+    expect(mockedIncr).toHaveBeenCalledTimes(3);
+
+    expect(result.success).toBe(true);
+    expect(result.response.numReposImported).toBe(3);
+  });
+
+  it('should only import projects that are not already imported', async () => {
+    (getConnectedGroups as jest.Mock).mockResolvedValue([MOCK_CONNECTED_GROUP_1]);
+    mockStorageGet.mockResolvedValue(MOCK_GROUP_TOKEN);
+
+    (getProjects as jest.Mock).mockResolvedValue({ data: MOCK_THREE_PROJECTS });
+    (compareProjectWithExistingComponent as jest.Mock).mockResolvedValueOnce({ hasComponent: false });
+    (compareProjectWithExistingComponent as jest.Mock).mockResolvedValueOnce({ hasComponent: false });
+    (compareProjectWithExistingComponent as jest.Mock).mockResolvedValueOnce({ hasComponent: true });
+
+    mockCreateComponent.mockResolvedValueOnce({ id: 1, name: 'repo1' } as unknown as Component);
+    mockCreateComponent.mockResolvedValueOnce({ id: 2, name: 'repo2' } as unknown as Component);
+
+    const result = await importRecentRepos({ cloudId: MOCK_CLOUD_ID, numRepos: 3 });
+
+    expect(getProjects).toHaveBeenCalledWith(MOCK_GROUP_TOKEN, MOCK_GROUP_ID_1, 1, 3, undefined, 'last_activity_at');
+
+    expect(mockCreateComponent).toHaveBeenCalledTimes(2);
+    expect(mockCreateComponent).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ name: 'repo1' }));
+    expect(mockCreateComponent).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ name: 'repo2' }));
+    expect(mockCreateComponent).not.toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ name: 'repo3' }),
+    );
+
+    expect(internalMetrics.counter).toHaveBeenCalledTimes(2);
+    expect(internalMetrics.counter).toHaveBeenCalledWith('compass.gitlab.import.end.success');
+    expect(mockedIncr).toHaveBeenCalledTimes(2);
+
+    expect(result.success).toBe(true);
+    expect(result.response.numReposImported).toBe(2);
+  });
+
+  it('should still return success if all projects are already imported', async () => {
+    (getConnectedGroups as jest.Mock).mockResolvedValue([MOCK_CONNECTED_GROUP_1]);
+    mockStorageGet.mockResolvedValue(MOCK_GROUP_TOKEN);
+
+    (getProjects as jest.Mock).mockResolvedValue({ data: MOCK_THREE_PROJECTS });
+    (compareProjectWithExistingComponent as jest.Mock).mockResolvedValue({ hasComponent: true });
+
+    const result = await importRecentRepos({ cloudId: MOCK_CLOUD_ID, numRepos: 3 });
+
+    expect(getProjects).toHaveBeenCalledWith(MOCK_GROUP_TOKEN, MOCK_GROUP_ID_1, 1, 3, undefined, 'last_activity_at');
+
+    expect(mockCreateComponent).toHaveBeenCalledTimes(0);
+
+    expect(internalMetrics.counter).toHaveBeenCalledTimes(0);
+    expect(mockedIncr).toHaveBeenCalledTimes(0);
+
+    expect(result.success).toBe(true);
+    expect(result.response.numReposImported).toBe(0);
+  });
+
+  it('should return error if no orgs are connected', async () => {
+    (getConnectedGroups as jest.Mock).mockResolvedValue([]);
+
+    const result = await importRecentRepos({ cloudId: MOCK_CLOUD_ID, numRepos: 3 });
+    expect(result.success).toBe(false);
+    expect(result.errors).toBe('No connected Gitlab groups');
+  });
+
+  it('should return error if getProjects fails', async () => {
+    (getConnectedGroups as jest.Mock).mockResolvedValue([MOCK_CONNECTED_GROUP_1]);
+    mockStorageGet.mockResolvedValue(MOCK_GROUP_TOKEN);
+
+    (getProjects as jest.Mock).mockRejectedValue(new Error('Search failed'));
+    const result = await importRecentRepos({ cloudId: MOCK_CLOUD_ID, numRepos: 3 });
+    expect(result.success).toBe(false);
+    expect(result.errors).toContain('Search failed');
+  });
+
+  it('should return error if some projects fail to import', async () => {
+    (getConnectedGroups as jest.Mock).mockResolvedValue([MOCK_CONNECTED_GROUP_1]);
+    mockStorageGet.mockResolvedValue(MOCK_GROUP_TOKEN);
+
+    (getProjects as jest.Mock).mockResolvedValue({ data: MOCK_THREE_PROJECTS });
+    (compareProjectWithExistingComponent as jest.Mock).mockResolvedValue({ hasComponent: false });
+
+    mockCreateComponent.mockResolvedValueOnce({ id: 1, name: 'repo1' } as unknown as Component);
+    mockCreateComponent.mockResolvedValueOnce({ id: 2, name: 'repo2' } as unknown as Component);
+    mockCreateComponent.mockRejectedValueOnce(new Error('Import failed for repo3'));
+
+    const result = await importRecentRepos({ cloudId: MOCK_CLOUD_ID, numRepos: 3 });
+
+    expect(getProjects).toHaveBeenCalledWith(MOCK_GROUP_TOKEN, MOCK_GROUP_ID_1, 1, 3, undefined, 'last_activity_at');
+
+    expect(mockCreateComponent).toHaveBeenCalledTimes(4);
+    expect(mockCreateComponent).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ name: 'repo1' }));
+    expect(mockCreateComponent).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ name: 'repo2' }));
+    expect(mockCreateComponent).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ name: 'repo3' }));
+
+    expect(internalMetrics.counter).toHaveBeenCalledTimes(3);
+    expect(internalMetrics.counter).toHaveBeenCalledWith('compass.gitlab.import.end.success');
+    expect(internalMetrics.counter).toHaveBeenCalledWith('compass.gitlab.import.end.fail');
+    expect(mockedIncr).toHaveBeenCalledTimes(3);
+
+    expect(result.success).toBe(false);
+    expect(result.response.numReposImported).toBe(2);
+  });
+
+  it('should return error if all projects fail to import', async () => {
+    (getConnectedGroups as jest.Mock).mockResolvedValue([MOCK_CONNECTED_GROUP_1]);
+    mockStorageGet.mockResolvedValue(MOCK_GROUP_TOKEN);
+
+    (getProjects as jest.Mock).mockResolvedValue({ data: MOCK_THREE_PROJECTS });
+    (compareProjectWithExistingComponent as jest.Mock).mockResolvedValue({ hasComponent: false });
+
+    mockCreateComponent.mockRejectedValueOnce(new Error('Import failed for repo1'));
+    mockCreateComponent.mockRejectedValueOnce(new Error('Import failed for repo2'));
+    mockCreateComponent.mockRejectedValueOnce(new Error('Import failed for repo3'));
+
+    const result = await importRecentRepos({ cloudId: MOCK_CLOUD_ID, numRepos: 3 });
+
+    expect(getProjects).toHaveBeenCalledWith(MOCK_GROUP_TOKEN, MOCK_GROUP_ID_1, 1, 3, undefined, 'last_activity_at');
+
+    expect(mockCreateComponent).toHaveBeenCalledTimes(6);
+    expect(mockCreateComponent).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ name: 'repo1' }));
+    expect(mockCreateComponent).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ name: 'repo2' }));
+    expect(mockCreateComponent).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ name: 'repo3' }));
+
+    expect(internalMetrics.counter).toHaveBeenCalledTimes(3);
+    expect(internalMetrics.counter).toHaveBeenCalledWith('compass.gitlab.import.end.fail');
+    expect(internalMetrics.counter).not.toHaveBeenCalledWith('compass.gitlab.import.end.success');
+    expect(mockedIncr).toHaveBeenCalledTimes(3);
+
+    expect(result.success).toBe(false);
+    expect(result.response.numReposImported).toBe(0);
+  });
+
+  it('should return success if there are less than the numRepos passed in', async () => {
+    (getConnectedGroups as jest.Mock).mockResolvedValue([MOCK_CONNECTED_GROUP_1]);
+    mockStorageGet.mockResolvedValue(MOCK_GROUP_TOKEN);
+
+    (getProjects as jest.Mock).mockResolvedValue({ data: MOCK_THREE_PROJECTS });
+    (compareProjectWithExistingComponent as jest.Mock).mockResolvedValue({ hasComponent: false });
+
+    mockCreateComponent.mockResolvedValueOnce({ id: 1, name: 'repo1' } as unknown as Component);
+    mockCreateComponent.mockResolvedValueOnce({ id: 2, name: 'repo2' } as unknown as Component);
+    mockCreateComponent.mockResolvedValueOnce({ id: 3, name: 'repo3' } as unknown as Component);
+
+    const result = await importRecentRepos({ cloudId: MOCK_CLOUD_ID, numRepos: 5 });
+
+    expect(getProjects).toHaveBeenCalledWith(MOCK_GROUP_TOKEN, MOCK_GROUP_ID_1, 1, 5, undefined, 'last_activity_at');
+
+    expect(mockCreateComponent).toHaveBeenCalledTimes(3);
+    expect(mockCreateComponent).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ name: 'repo1' }));
+    expect(mockCreateComponent).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ name: 'repo2' }));
+    expect(mockCreateComponent).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ name: 'repo3' }));
+
+    expect(internalMetrics.counter).toHaveBeenCalledTimes(3);
+    expect(internalMetrics.counter).toHaveBeenCalledWith('compass.gitlab.import.end.success');
+    expect(mockedIncr).toHaveBeenCalledTimes(3);
+
+    expect(result.success).toBe(true);
+    expect(result.response.numReposImported).toBe(3);
+  });
+});

--- a/src/entry/import-recent-repos/types.ts
+++ b/src/entry/import-recent-repos/types.ts
@@ -1,4 +1,5 @@
 export type ImportRecentReposPayload = {
+  cloudId: string;
   numRepos: number;
 };
 
@@ -8,4 +9,9 @@ export type ImportRecentReposReturn = {
   response: {
     numReposImported: number;
   };
+};
+
+export type ImportResultsSummary = {
+  successfulImports: number;
+  failedImports: number;
 };

--- a/src/resolvers/import-queue-resolver.ts
+++ b/src/resolvers/import-queue-resolver.ts
@@ -88,10 +88,10 @@ resolver.define('import', async (req) => {
       }
 
       if ('err' in updatedComponent) {
-        internalMetrics.counter('compass.bitbucket.import.end.fail').incr();
+        internalMetrics.counter('compass.gitlab.import.end.fail').incr();
         await setFailedRepositoriesToStore(project);
       } else {
-        internalMetrics.counter('compass.bitbucket.import.end.success').incr();
+        internalMetrics.counter('compass.gitlab.import.end.success').incr();
         console.log(
           `GitLab project was imported.
         Compass component - ${updatedComponent.id} was updated.`,
@@ -99,7 +99,7 @@ resolver.define('import', async (req) => {
       }
     }
   } catch (err) {
-    internalMetrics.counter('compass.bitbucket.import.end.fail').incr();
+    internalMetrics.counter('compass.gitlab.import.end.fail').incr();
     console.error(`Failed to create or update compass component for project "${id}" after all retries`, err);
 
     await setFailedRepositoriesToStore(project);

--- a/src/services/fetch-projects.ts
+++ b/src/services/fetch-projects.ts
@@ -69,7 +69,7 @@ const fetchProjects = async (
   }
 };
 
-const compareProjectWithExistingComponent = async (
+export const compareProjectWithExistingComponent = async (
   cloudId: string,
   projectId: number,
   groupToken: string,


### PR DESCRIPTION
# Description

Added logic to import `numRepos` from the connected gitlab group. Wrote some test cases. 
Tested some cases manually as well (i.e. happy path with 3 repos to import and fail case when no groups are connected).

![Screenshot 2025-01-27 at 2 02 40 PM](https://github.com/user-attachments/assets/debf8a66-53e5-4a52-8afd-e1a3fc994050)

# Checklist

Please ensure that each of these items has been addressed:

- [X] I have tested these changes in my local environment
- [X] I have added/modified tests as applicable to cover these changes
- [X] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links