### PR TITLE
Hide incoming webhook message in the onboarding flow

### DIFF
--- a/ui/src/components/AuthPage/index.tsx
+++ b/ui/src/components/AuthPage/index.tsx
@@ -411,7 +411,9 @@ export const AuthPage = () => {
             )}
           </TokenRoleWrapper>
           <ConnectionMessage />
-          <IncomingWebhookSectionMessage isMaintainerTokenEnabled={features.isGitlabMaintainerTokenEnabled} />
+          {!isOnboardingFlow && (
+            <IncomingWebhookSectionMessage isMaintainerTokenEnabled={features.isGitlabMaintainerTokenEnabled} />
+          )}
         </>
       )}
 

--- a/ui/src/components/IncomingWebhookSectionMessage.tsx
+++ b/ui/src/components/IncomingWebhookSectionMessage.tsx
@@ -9,7 +9,7 @@ type Props = {
 
 export const IncomingWebhookSectionMessage = ({ isMaintainerTokenEnabled = false }: Props) => {
   return (
-    <IncomingWebhookSectionWrapper>
+    <IncomingWebhookSectionWrapper data-testid='incoming-webhook-information'>
       <IncomingWebhookIcon src={WebhookIcon} />
       <div>
         <p>

--- a/ui/src/context/__tests__/AppContext.test.tsx
+++ b/ui/src/context/__tests__/AppContext.test.tsx
@@ -69,6 +69,23 @@ describe('AppContext', () => {
 
     expect(await findByTestId('gitlab-auth-page')).toBeDefined();
     expect(await findByTestId('token-setup-message')).toBeDefined();
+    expect(await findByTestId('incoming-webhook-information')).toBeDefined();
+  });
+
+  it('renders initial auth screen in onboarding without incoming webhook message', async () => {
+    mockInvoke(defaultMocks);
+    mockGetContext('admin-page-ui', 'onboardingFlow');
+
+    const { findByTestId, queryByTestId } = render(
+      <AppContextProvider>
+        <AppRouter />
+      </AppContextProvider>,
+    );
+
+    expect(await findByTestId('gitlab-auth-page')).toBeDefined();
+    expect(await findByTestId('token-setup-message')).toBeDefined();
+
+    expect(queryByTestId('incoming-webhook-information')).toBeNull();
   });
 
   it('renders webhooks setup screen', async () => {
@@ -96,6 +113,22 @@ describe('AppContext', () => {
     );
 
     expect(await findByTestId('gitlab-connected-page')).toBeDefined();
+    expect(await findByTestId('incoming-webhook-information')).toBeDefined();
+  });
+
+  it('renders connect screen in the onboarding without incoming webhook message', async () => {
+    mockInvoke(filledMocks);
+    mockGetContext('admin-page-ui', 'onboardingFlow');
+
+    const { findByTestId, queryByTestId } = render(
+      <AppContextProvider>
+        <AppRouter />
+      </AppContextProvider>,
+    );
+
+    expect(await findByTestId('gitlab-connected-page')).toBeDefined();
+
+    expect(queryByTestId('incoming-webhook-information')).toBeNull();
   });
 
   it('renders connected page with import all button, if FF_IMPORT_ALL_ENABLED ff is enabled', async () => {

--- a/ui/src/helpers/mockHelpers.ts
+++ b/ui/src/helpers/mockHelpers.ts
@@ -52,11 +52,13 @@ export const mockInvoke = (mocks = defaultMocks) => {
   });
 };
 
-export const mockGetContext = (moduleKey: string) => {
+export const mockGetContext = (moduleKey: string, renderingLocation = 'appConfigurationPage') => {
   getContext.mockImplementation(async () => {
     return {
       moduleKey,
-      extension: {},
+      extension: {
+        renderingLocation,
+      },
     };
   });
 };


### PR DESCRIPTION
# Description

Hide incoming webhook message in the onboarding flow

# Checklist

Please ensure that each of these items has been addressed:

- [x] I have tested these changes in my local environment
- [x] I have added/modified tests as applicable to cover these changes
- [x] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links