### PR TITLE
COMPASS-24188 Fixed cancel button to actually skip

### DIFF
--- a/ui/src/components/SelectImportPage/index.tsx
+++ b/ui/src/components/SelectImportPage/index.tsx
@@ -272,7 +272,7 @@ export const SelectImportPage = () => {
   };
 
   const handleNavigateToConnectedPage = async () => {
-    await checkOnboardingRedirection().catch((error) => {
+    await checkOnboardingRedirection('SKIP').catch((error) => {
       console.error('Error checking if context is in onboarding flow:', error);
     });
     await router.navigate('/compass/components');


### PR DESCRIPTION
# Description

Task: https://softwareteams.atlassian.net/browse/COMPASS-24188

Previously, the cancel button on the selectRepo screen would redirect you to the success page of the post import step in the onboarding tube. This fix makes it so it goes to the skipped page

# Checklist

Please ensure that each of these items has been addressed:

- [X] I have tested these changes in my local environment
- [ ] I have added/modified tests as applicable to cover these changes
- [ ] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links