### PR TITLE
Increase page size and add default filtering when fetching group access tokens

### DIFF
--- a/src/client/gitlab.ts
+++ b/src/client/gitlab.ts
@@ -177,12 +177,25 @@ export const getGroupWebhook = async (
   }
 };
 
-export const getGroupAccessTokens = async (groupToken: string, groupId: number): Promise<GroupAccessToken[]> => {
+export const getGroupAccessTokens = async (
+  groupToken: string,
+  groupId: number,
+  state = 'active',
+  pageSize = 100,
+): Promise<GroupAccessToken[]> => {
+  const params = {
+    ...(state ? { state } : {}),
+    ...(pageSize ? { per_page: pageSize.toString() } : {}),
+  };
+  const queryParams = queryParamsGenerator(params);
+
   const { data: groupAccessTokenList } = await callGitlab(
     'get group access tokens',
-    `/api/v4/groups/${groupId}/access_tokens`,
+    `/api/v4/groups/${groupId}/access_tokens?${queryParams}`,
     groupToken,
   );
+
+  console.log('Number of active access tokens fetched:', groupAccessTokenList.length);
 
   return groupAccessTokenList;
 };


### PR DESCRIPTION
# Description

Per https://docs.gitlab.com/ee/api/rest/#pagination the default page size is 20. And without supplying the `state` param ([docs](https://docs.gitlab.com/ee/api/group_access_tokens.html#list-group-access-tokens)), we pull back revoked tokens as well as active/non-revoked ones.

This is currently blocking a customer attempting to reconfigure their app https://community.atlassian.com/t5/Compass-questions/Updating-Gitlab-integration-api-key/qaq-p/2927476. Similar to what we did [here](https://github.com/atlassian-labs/gitlab-for-compass/pull/148) when getting `groups`.

# Checklist

Please ensure that each of these items has been addressed:

- [ ] I have tested these changes in my local environment
- [ ] I have added/modified tests as applicable to cover these changes
- [ ] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links