### PR TITLE
Increase default page size to 100 when fetching environments

### DIFF
--- a/src/client/gitlab.ts
+++ b/src/client/gitlab.ts
@@ -424,6 +424,8 @@ export const getEnvironments = async (
     groupToken,
   );
 
+  console.log('Number of environments fetched:', data.length);
+
   return data;
 };
 

--- a/src/client/gitlab.ts
+++ b/src/client/gitlab.ts
@@ -408,10 +408,19 @@ export const getProjectDeploymentById = async (projectId: number, deploymentId: 
   return data;
 };
 
-export const getEnvironments = async (projectId: number, groupToken: string): Promise<Environment[]> => {
+export const getEnvironments = async (
+  projectId: number,
+  groupToken: string,
+  pageSize = 100,
+): Promise<Environment[]> => {
+  const params = {
+    ...(pageSize ? { per_page: pageSize.toString() } : {}),
+  };
+  const queryParams = queryParamsGenerator(params);
+
   const { data } = await callGitlab(
     "get project's environments",
-    `/api/v4/projects/${projectId}/environments`,
+    `/api/v4/projects/${projectId}/environments?${queryParams}`,
     groupToken,
   );
 


### PR DESCRIPTION
# Description

Per https://docs.gitlab.com/ee/api/rest/#pagination the default page size is 20. Similar to what we did [here](https://github.com/atlassian-labs/gitlab-for-compass/pull/164).

I didn't include a `state` param ([docs](https://docs.gitlab.com/ee/api/environments.html#list-environments)) for fear of breaking clients with ephemeral environments.

# Checklist

Please ensure that each of these items has been addressed:

- [ ] I have tested these changes in my local environment
- [ ] I have added/modified tests as applicable to cover these changes
- [ ] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links