### PR TITLE
Remove Gitlab Maintainer token FF cloudId-based allowlist

### DIFF
--- a/src/resolvers/admin-resolvers.ts
+++ b/src/resolvers/admin-resolvers.ts
@@ -146,12 +146,8 @@ resolver.define('project/import', async (req): Promise<ResolverResponse> => {
   return importProject(req);
 });
 
-resolver.define('features', (req): ResolverResponse<FeaturesList> => {
-  const {
-    context: { cloudId },
-  } = req;
-
-  return getFeatures(cloudId);
+resolver.define('features', (): ResolverResponse<FeaturesList> => {
+  return getFeatures();
 });
 
 resolver.define('appId', (): ResolverResponse<string> => {

--- a/src/resolvers/import-resolvers.ts
+++ b/src/resolvers/import-resolvers.ts
@@ -73,12 +73,8 @@ resolver.define('project/import/clear', async (): Promise<ResolverResponse> => {
   }
 });
 
-resolver.define('features', (req): ResolverResponse<FeaturesList> => {
-  const {
-    context: { cloudId },
-  } = req;
-
-  return getFeatures(cloudId);
+resolver.define('features', (): ResolverResponse<FeaturesList> => {
+  return getFeatures();
 });
 
 resolver.define('appId', (): ResolverResponse<string> => {

--- a/src/resolvers/shared-resolvers.ts
+++ b/src/resolvers/shared-resolvers.ts
@@ -17,9 +17,9 @@ import { getGroupProjects } from '../services/fetch-projects';
 import { ImportFailedError, importProjects } from '../services/import-projects';
 import { getAllComponentTypes as getAllCompassComponentTypes } from '../client/compass';
 
-export const getFeatures = (cloudId: string): ResolverResponse<FeaturesList> => {
+export const getFeatures = (): ResolverResponse<FeaturesList> => {
   try {
-    const features = listFeatures(cloudId);
+    const features = listFeatures();
     return {
       success: true,
       data: features,

--- a/src/services/feature-flags.test.ts
+++ b/src/services/feature-flags.test.ts
@@ -18,23 +18,4 @@ describe('listFeatures', () => {
 
     expect(featureFlags.isSendStagingEventsEnabled).toEqual(false);
   });
-
-  it('uses cloudId to determine if gitlab maintainer token is enabled', async () => {
-    process.env.ENABLE_GITLAB_MAINTAINER_TOKEN_CLOUD_IDS = 'cloudId1,cloudId2';
-    process.env.ENABLE_GITLAB_MAINTAINER_TOKEN = 'true';
-
-    let featureFlags = listFeatures('cloudId1');
-    expect(featureFlags.isGitlabMaintainerTokenEnabled).toEqual(true);
-
-    featureFlags = listFeatures();
-    expect(featureFlags.isGitlabMaintainerTokenEnabled).toEqual(true);
-
-    featureFlags = listFeatures('cloudId3');
-    expect(featureFlags.isGitlabMaintainerTokenEnabled).toEqual(false);
-
-    process.env.ENABLE_GITLAB_MAINTAINER_TOKEN_CLOUD_IDS = '';
-
-    featureFlags = listFeatures('cloudId1');
-    expect(featureFlags.isGitlabMaintainerTokenEnabled).toEqual(true);
-  });
 });

--- a/src/services/feature-flags.ts
+++ b/src/services/feature-flags.ts
@@ -11,27 +11,20 @@ const isDocumentComponentLinksDisabled = (defaultValue = false): boolean => {
   return process.env.DISABLE_DOCUMENT_COMPONENT_LINKS === 'true' || defaultValue;
 };
 
-export const isGitlabMaintainerTokenEnabled = (cloudId?: string, defaultValue = false): boolean => {
-  // cloudId is available in frontend context when fetching features for AppContext.
-  // It is not available in all backend contexts, so we will use the default value if it is not provided.
-  const isEnabledForCloudId =
-    !!cloudId && !!process.env.ENABLE_GITLAB_MAINTAINER_TOKEN_CLOUD_IDS
-      ? process.env.ENABLE_GITLAB_MAINTAINER_TOKEN_CLOUD_IDS.split(',').includes(cloudId)
-      : true;
-
-  return (process.env.ENABLE_GITLAB_MAINTAINER_TOKEN === 'true' && isEnabledForCloudId) || defaultValue;
+export const isGitlabMaintainerTokenEnabled = (defaultValue = false): boolean => {
+  return process.env.ENABLE_GITLAB_MAINTAINER_TOKEN === 'true' || defaultValue;
 };
 
 const isImportAllEnabled = (defaultValue = false): boolean => {
   return process.env.FF_IMPORT_ALL_ENABLED === 'true' || defaultValue;
 };
 
-export const listFeatures = (cloudId?: string): FeaturesList => {
+export const listFeatures = (): FeaturesList => {
   return {
     [GitlabFeaturesEnum.SEND_STAGING_EVENTS]: isSendStagingEventsEnabled(),
     [GitlabFeaturesEnum.DATA_COMPONENT_TYPES]: isDataComponentTypesEnabled(),
     [GitlabFeaturesEnum.DISABLE_DOCUMENT_COMPONENT_LINKS]: isDocumentComponentLinksDisabled(),
-    [GitlabFeaturesEnum.ENABLE_GITLAB_MAINTAINER_TOKEN]: isGitlabMaintainerTokenEnabled(cloudId),
+    [GitlabFeaturesEnum.ENABLE_GITLAB_MAINTAINER_TOKEN]: isGitlabMaintainerTokenEnabled(),
     [GitlabFeaturesEnum.IMPORT_ALL]: isImportAllEnabled(),
   };
 };


### PR DESCRIPTION
# Description

Remove cloudId-based allow listing for GA. Rest of the FF will be cleaned up after launch.

# Checklist

Please ensure that each of these items has been addressed:

- [ ] I have tested these changes in my local environment
- [x] I have added/modified tests as applicable to cover these changes
- [ ] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links