### PR TITLE
Add support for isMonorepoProject field in config-as-code

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "typescript": "~4.5.5"
   },
   "dependencies": {
-    "@atlassian/forge-graphql": "13.23.0",
+    "@atlassian/forge-graphql": "13.23.2",
     "@forge/api": "^4.1.1",
     "@forge/bridge": "^3.5.0",
     "@forge/events": "^0.9.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -24,7 +24,7 @@
     "@atlaskit/theme": "^12.1.6",
     "@atlaskit/tokens": "^1.29.1",
     "@atlaskit/tooltip": "^17.5.9",
-    "@atlassian/forge-graphql": "13.23.0",
+    "@atlassian/forge-graphql": "13.23.2",
     "@forge/bridge": "^3.5.0",
     "escape-string-regexp": "^5.0.0",
     "lodash": "^4.17.21",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1091,10 +1091,10 @@
     "@babel/runtime" "^7.0.0"
     "@emotion/react" "^11.7.1"
 
-"@atlassian/forge-graphql@13.23.0":
-  version "13.23.0"
-  resolved "https://registry.yarnpkg.com/@atlassian/forge-graphql/-/forge-graphql-13.23.0.tgz#e9dda340575b57580848b9a1a2ea70e05d1070bb"
-  integrity sha512-ArgZmrjOhU1Zb8XFu9t1k80xWWnY8xw7X1nQIYRe7P8s05kjB+Y4Ye6YuXDaP7nGXoRypiOYgfZrJ7hpnWkXMg==
+"@atlassian/forge-graphql@13.23.2":
+  version "13.23.2"
+  resolved "https://registry.yarnpkg.com/@atlassian/forge-graphql/-/forge-graphql-13.23.2.tgz#0023bfa5a50c22b21555f2f613cec6193b833cf6"
+  integrity sha512-R780560Z/JJbbHmEi/tSXJvIcI6Ie+M+OQ6vUn9r980VMoNCh6yg4bQk+/eqR8Fmb+5utBaooEzeyiq1+Hgp9Q==
   dependencies:
     "@forge/api" "^5.0.0"
     "@forge/metrics" "0.2.25"

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,10 +57,10 @@
     "@babel/types" "^7.20.0"
     bind-event-listener "^2.1.1"
 
-"@atlassian/forge-graphql@13.23.0":
-  version "13.23.0"
-  resolved "https://registry.yarnpkg.com/@atlassian/forge-graphql/-/forge-graphql-13.23.0.tgz#e9dda340575b57580848b9a1a2ea70e05d1070bb"
-  integrity sha512-ArgZmrjOhU1Zb8XFu9t1k80xWWnY8xw7X1nQIYRe7P8s05kjB+Y4Ye6YuXDaP7nGXoRypiOYgfZrJ7hpnWkXMg==
+"@atlassian/forge-graphql@13.23.2":
+  version "13.23.2"
+  resolved "https://registry.yarnpkg.com/@atlassian/forge-graphql/-/forge-graphql-13.23.2.tgz#0023bfa5a50c22b21555f2f613cec6193b833cf6"
+  integrity sha512-R780560Z/JJbbHmEi/tSXJvIcI6Ie+M+OQ6vUn9r980VMoNCh6yg4bQk+/eqR8Fmb+5utBaooEzeyiq1+Hgp9Q==
   dependencies:
     "@forge/api" "^5.0.0"
     "@forge/metrics" "0.2.25"


### PR DESCRIPTION
# Description

Pulls in the latest forge-graphql which supports the isMonorepoProject field for config-as-code. 

# Checklist

Please ensure that each of these items has been addressed:

- [X] I have tested these changes in my local environment
- [ ] I have added/modified tests as applicable to cover these changes
- [X] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links