### PR TITLE
Add push event type to data-provider

### DIFF
--- a/src/entry/data-provider/__snapshots__/test.ts.snap
+++ b/src/entry/data-provider/__snapshots__/test.ts.snap
@@ -71,5 +71,8 @@ Object {
       },
     ],
   },
+  "pushes": Object {
+    "initialValues": null,
+  },
 }
 `;

--- a/src/entry/data-provider/index.ts
+++ b/src/entry/data-provider/index.ts
@@ -13,6 +13,7 @@ import { getProjectDataFromUrl } from '../../services/data-provider-link-parser'
 import { getTrackingBranchName } from '../../services/get-tracking-branch';
 import { getBackfillData } from '../../services/get-backfill-data';
 import { GitlabHttpMethodError } from '../../models/errors';
+import { isCompassPushEventEnabled } from '../../services/feature-flags';
 
 export const dataProvider = async (
   request: DataProviderPayload,
@@ -81,8 +82,13 @@ export const dataProvider = async (
     ).build();
   }
 
+  const supportedEventTypes = [DataProviderEventTypes.BUILDS, DataProviderEventTypes.DEPLOYMENTS];
+  if (isCompassPushEventEnabled()) {
+    supportedEventTypes.push(DataProviderEventTypes.PUSH);
+  }
+
   const response = new DataProviderResponse(projectId.toString(), {
-    eventTypes: [DataProviderEventTypes.BUILDS, DataProviderEventTypes.DEPLOYMENTS],
+    eventTypes: supportedEventTypes,
     builtInMetricDefinitions: [
       {
         name: BuiltinMetricDefinitions.WEEKLY_DEPLOYMENT_FREQUENCY_28D,

--- a/src/entry/data-provider/test.ts
+++ b/src/entry/data-provider/test.ts
@@ -18,6 +18,7 @@ import * as getProjectDataFromUrl from '../../services/data-provider-link-parser
 import * as getTrackingBranchName from '../../services/get-tracking-branch';
 import { GitlabAPIProject } from '../../types';
 import { GitlabHttpMethodError } from '../../models/errors';
+import * as featureFlagService from '../../services/feature-flags';
 
 const getEventsSpy = jest.spyOn(getBackfillEvents, 'getBackfillData');
 const projectDataSpy = jest.spyOn(getProjectDataFromUrl, 'getProjectDataFromUrl');
@@ -88,6 +89,7 @@ const MOCK_PROJECT: GitlabAPIProject = {
 
 describe('dataProvider module', () => {
   it('successfully returns events and metrics in the expected format', async () => {
+    jest.spyOn(featureFlagService, 'isCompassPushEventEnabled').mockReturnValue(true);
     getEventsSpy.mockResolvedValue(MOCK_EVENTS_RESPONSE);
     projectDataSpy.mockResolvedValue({
       project: MOCK_PROJECT,
@@ -110,6 +112,34 @@ describe('dataProvider module', () => {
     expect(dataProviderResult.externalSourceId).toEqual(MOCK_PROJECT.id.toString());
     expect(dataProviderResult.metrics).toMatchSnapshot();
     expect(dataProviderResult.events).toMatchSnapshot();
+    expect(dataProviderResult.events.pushes).toEqual({
+      initialValues: null,
+    });
+  });
+
+  it('when FF isCompassPushEventEnabled is false, push eventType is not returned', async () => {
+    jest.spyOn(featureFlagService, 'isCompassPushEventEnabled').mockReturnValue(false);
+    getEventsSpy.mockResolvedValue(MOCK_EVENTS_RESPONSE);
+    projectDataSpy.mockResolvedValue({
+      project: MOCK_PROJECT,
+      groupToken: 'mock-group-token',
+      groupId: 123,
+    });
+
+    trackingBranchSpy.mockResolvedValue('branch');
+
+    const result = await dataProvider({
+      url: MOCK_PROJECT_URL,
+      ctx: {
+        cloudId: 'ari:cloud:compass:122345:component/12345/12345',
+        extensionId: 'mock-extension-id',
+      },
+    });
+
+    const dataProviderResult = result as DataProviderResult;
+
+    expect(dataProviderResult.externalSourceId).toEqual(MOCK_PROJECT.id.toString());
+    expect(dataProviderResult.events.pushes).toBeUndefined();
   });
 
   it('returns error from ForgeInvokationErrorResponse class in case of invocation error from getBackfillData', async () => {


### PR DESCRIPTION
# Description
This change adds the `PUSH` event type to the data-provider. 
This is a follow up to https://github.com/atlassian-labs/gitlab-for-compass/pull/177

# Checklist

- [✅] I have tested these changes in my local environment
- [✅] I have added/modified tests as applicable to cover these changes
- [✅] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links