### PR TITLE
Add support for conditional backfilling by eventType

### DIFF
--- a/src/entry/data-provider/index.ts
+++ b/src/entry/data-provider/index.ts
@@ -61,7 +61,7 @@ export const dataProvider = async (
       builds,
       deployments,
       metrics: { mrCycleTime, openMergeRequestsCount },
-    } = await getBackfillData(groupToken, projectId, projectName, trackingBranch);
+    } = await getBackfillData(groupToken, projectId, projectName, trackingBranch, request.options?.eventTypes);
 
     backfillData.builds = builds;
     backfillData.deployments = deployments;

--- a/src/entry/data-provider/types.ts
+++ b/src/entry/data-provider/types.ts
@@ -1,10 +1,13 @@
-import { DataProviderBuildEvent, DataProviderDeploymentEvent } from '@atlassian/forge-graphql';
+import { CompassEventType, DataProviderBuildEvent, DataProviderDeploymentEvent } from '@atlassian/forge-graphql';
 
 type DataProviderPayload = {
   url: string;
   ctx: {
     cloudId: string;
     extensionId: string;
+  };
+  options?: {
+    eventTypes?: CompassEventType[];
   };
 };
 

--- a/src/services/__mocks__/mocks.ts
+++ b/src/services/__mocks__/mocks.ts
@@ -1,0 +1,55 @@
+import {
+  CompassBuildEventState,
+  CompassDeploymentEventEnvironmentCategory,
+  CompassDeploymentEventState,
+  DataProviderBuildEvent,
+  DataProviderDeploymentEvent,
+} from '@atlassian/forge-graphql';
+import { BackfillData } from '../../entry/data-provider/types';
+
+export const MOCK_BUILD_EVENT: DataProviderBuildEvent = {
+  pipeline: {
+    pipelineId: 'pipeline-id',
+  },
+  startedAt: 'started-at',
+  completedAt: 'completed-at',
+  state: CompassBuildEventState.Successful,
+  description: 'mock description',
+  displayName: 'mock display name',
+  updateSequenceNumber: 1,
+  lastUpdated: 'updated',
+  url: 'url',
+};
+
+export const MOCK_DEPLOY_EVENT: DataProviderDeploymentEvent = {
+  displayName: 'name',
+  lastUpdated: 'mock',
+  updateSequenceNumber: '1',
+  url: 'url',
+  environment: {
+    category: CompassDeploymentEventEnvironmentCategory.Production,
+    displayName: 'prod',
+    environmentId: 'id',
+  },
+  pipeline: { pipelineId: '1', displayName: 'pipeline', url: 'url' },
+  sequenceNumber: 1,
+  state: CompassDeploymentEventState.Successful,
+};
+
+export const MOCK_BACKFILL_RESPONSE = {
+  builds: [MOCK_BUILD_EVENT],
+  deployments: [MOCK_DEPLOY_EVENT],
+  metrics: {
+    mrCycleTime: 1,
+    openMergeRequestsCount: 3,
+  },
+} as BackfillData;
+
+export const MOCK_EMPTY_BACKFILL_RESPONSE = {
+  builds: [],
+  deployments: [],
+  metrics: {
+    mrCycleTime: null,
+    openMergeRequestsCount: null,
+  },
+} as BackfillData;

--- a/src/services/get-backfill-data.test.ts
+++ b/src/services/get-backfill-data.test.ts
@@ -1,0 +1,127 @@
+import { CompassEventType } from '@atlassian/forge-graphql';
+import { getBackfillData } from './get-backfill-data';
+
+import * as getProjectBuildsFor28Days from './compute-event-and-metrics/get-recent-builds';
+import * as getDeploymentsForEnvironmentTiers from './compute-event-and-metrics/get-recent-deployments';
+import * as getMRCycleTime from './compute-event-and-metrics/get-mr-cycle-time';
+import * as getOpenMergeRequestsCount from './compute-event-and-metrics/get-open-merge-requests';
+import { MOCK_BUILD_EVENT, MOCK_DEPLOY_EVENT } from './__mocks__/mocks';
+
+const getBuildsSpy = jest.spyOn(getProjectBuildsFor28Days, 'getProjectBuildsFor28Days');
+const getCycleTimeSpy = jest.spyOn(getMRCycleTime, 'getMRCycleTime');
+const getDeploymentsSpy = jest.spyOn(getDeploymentsForEnvironmentTiers, 'getDeploymentsForEnvironmentTiers');
+const getOpenMergeRequestsSpy = jest.spyOn(getOpenMergeRequestsCount, 'getOpenMergeRequestsCount');
+
+const MOCK_PROJECT_ID = 12345;
+
+describe('get backfill data', () => {
+  const nonBackfillEvents = Object.values(CompassEventType).filter(
+    (eventType) =>
+      ![CompassEventType.Build, CompassEventType.Deployment, CompassEventType.PullRequest].includes(eventType),
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getBuildsSpy.mockResolvedValue([MOCK_BUILD_EVENT]);
+    getDeploymentsSpy.mockResolvedValue([MOCK_DEPLOY_EVENT]);
+    getCycleTimeSpy.mockResolvedValue(10);
+    getOpenMergeRequestsSpy.mockResolvedValue(10);
+  });
+
+  it('successfully returns all available events', async () => {
+    const result = await getBackfillData('mock-group-token', MOCK_PROJECT_ID, 'mock-project-name', 'branch', null);
+
+    expect(result).toEqual({
+      builds: [MOCK_BUILD_EVENT],
+      deployments: [MOCK_DEPLOY_EVENT],
+      metrics: {
+        mrCycleTime: 10,
+        openMergeRequestsCount: 10,
+      },
+    });
+
+    expect(getBuildsSpy).toHaveBeenCalled();
+    expect(getCycleTimeSpy).toHaveBeenCalled();
+    expect(getDeploymentsSpy).toHaveBeenCalled();
+    expect(getOpenMergeRequestsSpy).toHaveBeenCalled();
+  });
+
+  it('should return build events only', async () => {
+    const result = await getBackfillData('mock-group-token', MOCK_PROJECT_ID, 'mock-project-name', 'branch', [
+      CompassEventType.Build,
+    ]);
+    expect(result).toEqual({
+      builds: [MOCK_BUILD_EVENT],
+      deployments: [],
+      metrics: {
+        mrCycleTime: null,
+        openMergeRequestsCount: null,
+      },
+    });
+
+    expect(getBuildsSpy).toHaveBeenCalled();
+    expect(getCycleTimeSpy).not.toHaveBeenCalled();
+    expect(getDeploymentsSpy).not.toHaveBeenCalled();
+    expect(getOpenMergeRequestsSpy).not.toHaveBeenCalled();
+  });
+
+  it('should return deployment events only', async () => {
+    const result = await getBackfillData('mock-group-token', MOCK_PROJECT_ID, 'mock-project-name', 'branch', [
+      CompassEventType.Deployment,
+    ]);
+    expect(result).toEqual({
+      builds: [],
+      deployments: [MOCK_DEPLOY_EVENT],
+      metrics: {
+        mrCycleTime: null,
+        openMergeRequestsCount: null,
+      },
+    });
+
+    expect(getBuildsSpy).not.toHaveBeenCalled();
+    expect(getCycleTimeSpy).not.toHaveBeenCalled();
+    expect(getDeploymentsSpy).toHaveBeenCalled();
+    expect(getOpenMergeRequestsSpy).not.toHaveBeenCalled();
+  });
+
+  it('should return PR metrics events only', async () => {
+    const result = await getBackfillData('mock-group-token', MOCK_PROJECT_ID, 'mock-project-name', 'branch', [
+      CompassEventType.PullRequest,
+    ]);
+    expect(result).toEqual({
+      builds: [],
+      deployments: [],
+      metrics: {
+        mrCycleTime: 10,
+        openMergeRequestsCount: 10,
+      },
+    });
+
+    expect(getBuildsSpy).not.toHaveBeenCalled();
+    expect(getCycleTimeSpy).toHaveBeenCalled();
+    expect(getDeploymentsSpy).not.toHaveBeenCalled();
+    expect(getOpenMergeRequestsSpy).toHaveBeenCalled();
+  });
+
+  test.each(nonBackfillEvents)(
+    'should return empty backfill results for %s event types',
+    async (eventType: CompassEventType) => {
+      const result = await getBackfillData('mock-group-token', MOCK_PROJECT_ID, 'mock-project-name', 'branch', [
+        eventType,
+      ]);
+      expect(result).toEqual({
+        builds: [],
+        deployments: [],
+        metrics: {
+          mrCycleTime: null,
+          openMergeRequestsCount: null,
+        },
+      });
+
+      expect(getBuildsSpy).not.toHaveBeenCalled();
+      expect(getCycleTimeSpy).not.toHaveBeenCalled();
+      expect(getDeploymentsSpy).not.toHaveBeenCalled();
+      expect(getOpenMergeRequestsSpy).not.toHaveBeenCalled();
+    },
+  );
+});


### PR DESCRIPTION
# Description

This change adds support for conditional backfilling.
It uses an optional `options.eventTypes` variable to allow the caller limit the type of backfilling data requested.

# Checklist

- [✅] I have tested these changes in my local environment
- [✅] I have added/modified tests as applicable to cover these changes
- [✅] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links