### PR TITLE
Add dataProvider backfilling for PUSH event type

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -59,7 +59,7 @@ modules:
   scheduledTrigger:
     - key: backfill
       function: backfill-fn
-      interval: fiveMinute
+      interval: hour
   function:
     - key: admin-resolver
       handler: index.adminResolver

--- a/manifest.yml
+++ b/manifest.yml
@@ -54,6 +54,12 @@ modules:
   webtrigger:
     - key: gitlab-event-webtrigger
       function: process-gitlab-event
+    - key: test-trigger
+      function: data-provider-fn
+  scheduledTrigger:
+    - key: backfill
+      function: backfill-fn
+      interval: fiveMinute
   function:
     - key: admin-resolver
       handler: index.adminResolver
@@ -79,12 +85,21 @@ modules:
       handler: index.getFileContents
     - key: get-tree-shallow-fn
       handler: index.getTreeShallow
+    - key: backfill-fn
+      handler: index.dataProviderBackfill
+    - key: backfill-consumer-fn
+      handler: index.backfillQueueResolver
   consumer:
     - key: import-consumer
       queue: import-queue
       resolver:
         function: import-projects
         method: import
+    - key: backfill-consumer
+      queue: data-provider-backfill
+      resolver:
+        function: backfill-consumer-fn
+        method: dataProviderBackfill
 app:
   id: ari:cloud:ecosystem::app/60787eba-aec5-49b4-979d-db8e77de32db
   runtime:

--- a/manifest.yml
+++ b/manifest.yml
@@ -54,8 +54,6 @@ modules:
   webtrigger:
     - key: gitlab-event-webtrigger
       function: process-gitlab-event
-    - key: test-trigger
-      function: data-provider-fn
   scheduledTrigger:
     - key: backfill
       function: backfill-fn

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,7 @@ export const STORAGE_KEYS = {
   CURRENT_IMPORT_QUEUE_JOB_IDS: 'currentImportQueueJobIds',
   CURRENT_IMPORT_FAILED_PROJECT_PREFIX: 'currentImportFailedProject-',
   TEAM_ONBOARDING: 'isTeamOnboardingCompleted',
+  BACKFILL_PUSH_DATA_PROVIDER_VERSION: 'backfill-push-data-provider',
 };
 
 export const STORAGE_SECRETS = {

--- a/src/entry/scheduled-triggers/data-provider-backfill.ts
+++ b/src/entry/scheduled-triggers/data-provider-backfill.ts
@@ -1,12 +1,26 @@
 import { Queue } from '@forge/events';
+import { storage } from '@forge/api';
 import { WebtriggerRequest } from '../../types';
 import { isCompassPushEventEnabled } from '../../services/feature-flags';
+import { STORAGE_KEYS } from '../../constants';
+
+export const CURRENT_BACKFILL_VERSION = 1;
+
+const getBackfillVersion = async (): Promise<number> => {
+  return (await storage.get(STORAGE_KEYS.BACKFILL_PUSH_DATA_PROVIDER_VERSION)) || 0;
+};
 
 export default async function dataProviderBackfill(req: WebtriggerRequest): Promise<void> {
   const queue = new Queue({ key: 'data-provider-backfill' });
 
   if (!isCompassPushEventEnabled()) {
     console.log('Compass push event is not enabled');
+    return;
+  }
+
+  const backfillVersion = await getBackfillVersion();
+  if (backfillVersion >= CURRENT_BACKFILL_VERSION) {
+    console.log(`Skipping backfill as it already has the latest version (v${backfillVersion})`);
     return;
   }
 

--- a/src/entry/scheduled-triggers/data-provider-backfill.ts
+++ b/src/entry/scheduled-triggers/data-provider-backfill.ts
@@ -1,0 +1,23 @@
+import { Queue } from '@forge/events';
+import { WebtriggerRequest } from '../../types';
+import { isCompassPushEventEnabled } from '../../services/feature-flags';
+
+export default async function dataProviderBackfill(req: WebtriggerRequest): Promise<void> {
+  const queue = new Queue({ key: 'data-provider-backfill' });
+
+  if (!isCompassPushEventEnabled()) {
+    console.log('Compass push event is not enabled');
+    return;
+  }
+
+  // space out the requests over 15 mins because they all get triggered at the same time
+  const queueDelayInSeconds = Math.floor(Math.random() * 900);
+  await queue.push(
+    {
+      cloudId: req.context.cloudId,
+    },
+    {
+      delayInSeconds: queueDelayInSeconds,
+    },
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import adminResolver from './resolvers/admin-resolvers';
 import importResolver from './resolvers/import-resolvers';
 import importQueueResolver from './resolvers/import-queue-resolver';
+import backfillQueueResolver from './resolvers/backfill-queue-resolver';
 
 import { processGitlabEvent } from './entry/webtriggers';
 import { dataProvider } from './entry/data-provider';
@@ -12,12 +13,16 @@ import { getRepoDetails } from './entry/get-repo-details';
 import { getTreeShallow } from './entry/get-tree-shallow';
 import { getFileContents } from './entry/get-file-contents';
 
+import dataProviderBackfill from './entry/scheduled-triggers/data-provider-backfill';
+
 // extension points
 export { preUninstall };
 // webtriggers
 export { processGitlabEvent };
+// scheduled triggers
+export { dataProviderBackfill };
 // resolvers
-export { adminResolver, importResolver, importQueueResolver };
+export { adminResolver, importResolver, importQueueResolver, backfillQueueResolver };
 // dataProvider
 export { dataProvider, callback };
 // configValidator

--- a/src/resolvers/backfill-queue-resolver.ts
+++ b/src/resolvers/backfill-queue-resolver.ts
@@ -1,5 +1,8 @@
 import Resolver from '@forge/resolver';
 import graphqlGateway, { CompassEventType } from '@atlassian/forge-graphql';
+import { storage } from '@forge/api';
+import { STORAGE_KEYS } from '../constants';
+import { CURRENT_BACKFILL_VERSION } from '../entry/scheduled-triggers/data-provider-backfill';
 
 const resolver = new Resolver();
 type ReqPayload = {
@@ -23,6 +26,7 @@ resolver.define('dataProviderBackfill', async (req) => {
   });
 
   if (result.success) {
+    await storage.set(STORAGE_KEYS.BACKFILL_PUSH_DATA_PROVIDER_VERSION, CURRENT_BACKFILL_VERSION);
     console.log('BACKFILL: synchronize link associations success');
   } else {
     console.error('BACKFILL: synchronize link associations failure', result.errors);

--- a/src/resolvers/backfill-queue-resolver.ts
+++ b/src/resolvers/backfill-queue-resolver.ts
@@ -1,0 +1,32 @@
+import Resolver from '@forge/resolver';
+import graphqlGateway, { CompassEventType } from '@atlassian/forge-graphql';
+
+const resolver = new Resolver();
+type ReqPayload = {
+  cloudId: string;
+};
+
+resolver.define('dataProviderBackfill', async (req) => {
+  const { cloudId } = req.payload as ReqPayload;
+  console.log({
+    message: 'BACKFILL: dataProviderBackfill queue invocation',
+    cloudId,
+  });
+
+  // call sync link associations
+  const result = await graphqlGateway.compass.asApp().synchronizeLinkAssociations({
+    cloudId,
+    forgeAppId: process.env.FORGE_APP_ID,
+    options: {
+      eventTypes: [CompassEventType.Push],
+    },
+  });
+
+  if (result.success) {
+    console.log('BACKFILL: synchronize link associations success');
+  } else {
+    console.error('BACKFILL: synchronize link associations failure', result.errors);
+  }
+});
+
+export default resolver.getDefinitions();


### PR DESCRIPTION
# Description
This change adds a scheduled event (with a corresponding consumer) to nudge Compass to call dataProvider in other to get the new PUSH event type

This change has a soft dependency on https://github.com/atlassian-labs/gitlab-for-compass/pull/181

# Checklist

- [✅] I have tested these changes in my local environment
- [✅] I have added/modified tests as applicable to cover these changes
- [✅] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links