### PR TITLE
Escaping dot in urlFilterRegex

### DIFF
--- a/src/resolvers/admin-resolvers.ts
+++ b/src/resolvers/admin-resolvers.ts
@@ -84,7 +84,7 @@ resolver.define('groups/connect', async (req): Promise<ResolverResponse> => {
       cloudId,
       forgeAppId: getForgeAppId(),
       options: {
-        ...(group && { urlFilterRegex: `.*gitlab\\.com/.*${group.path}.*` }), // eslint-disable-line no-useless-escape
+        ...(group && { urlFilterRegex: `.*gitlab\.com/.*${group.path}.*` }), // eslint-disable-line no-useless-escape
       },
     });
 
@@ -125,7 +125,7 @@ resolver.define('webhooks/connectInProgress', async (req): Promise<ResolverRespo
       cloudId,
       forgeAppId: getForgeAppId(),
       options: {
-        ...(group && { urlFilterRegex: `.*gitlab\\.com/.*${group.path}.*` }), // eslint-disable-line no-useless-escape
+        ...(group && { urlFilterRegex: `.*gitlab\.com/.*${group.path}.*` }), // eslint-disable-line no-useless-escape
       },
     });
 

--- a/src/resolvers/admin-resolvers.ts
+++ b/src/resolvers/admin-resolvers.ts
@@ -84,7 +84,7 @@ resolver.define('groups/connect', async (req): Promise<ResolverResponse> => {
       cloudId,
       forgeAppId: getForgeAppId(),
       options: {
-        ...(group && { urlFilterRegex: `.*gitlab.com/.*${group.path}.*` }),
+        ...(group && { urlFilterRegex: `.*gitlab\.com/.*${group.path}.*` }),
       },
     });
 
@@ -125,7 +125,7 @@ resolver.define('webhooks/connectInProgress', async (req): Promise<ResolverRespo
       cloudId,
       forgeAppId: getForgeAppId(),
       options: {
-        ...(group && { urlFilterRegex: `.*gitlab.com/.*${group.path}.*` }),
+        ...(group && { urlFilterRegex: `.*gitlab\.com/.*${group.path}.*` }),
       },
     });
 

--- a/src/resolvers/admin-resolvers.ts
+++ b/src/resolvers/admin-resolvers.ts
@@ -84,7 +84,7 @@ resolver.define('groups/connect', async (req): Promise<ResolverResponse> => {
       cloudId,
       forgeAppId: getForgeAppId(),
       options: {
-        ...(group && { urlFilterRegex: `.*gitlab\.com/.*${group.path}.*` }),
+        ...(group && { urlFilterRegex: `.*gitlab\\.com/.*${group.path}.*` }), // eslint-disable-line no-useless-escape
       },
     });
 
@@ -125,7 +125,7 @@ resolver.define('webhooks/connectInProgress', async (req): Promise<ResolverRespo
       cloudId,
       forgeAppId: getForgeAppId(),
       options: {
-        ...(group && { urlFilterRegex: `.*gitlab\.com/.*${group.path}.*` }),
+        ...(group && { urlFilterRegex: `.*gitlab\\.com/.*${group.path}.*` }), // eslint-disable-line no-useless-escape
       },
     });
 

--- a/src/resolvers/mocks.ts
+++ b/src/resolvers/mocks.ts
@@ -14,4 +14,4 @@ export const MOCK_GROUP = {
   id: MOCK_GROUP_ID,
   path: MOCK_GROUP_PATH,
 };
-export const MOCK_URL_REGEX = `.*gitlab\.com/.*${MOCK_GROUP_PATH}.*`;
+export const MOCK_URL_REGEX = `.*gitlab\\.com/.*${MOCK_GROUP_PATH}.*`;

--- a/src/resolvers/mocks.ts
+++ b/src/resolvers/mocks.ts
@@ -14,4 +14,4 @@ export const MOCK_GROUP = {
   id: MOCK_GROUP_ID,
   path: MOCK_GROUP_PATH,
 };
-export const MOCK_URL_REGEX = `.*gitlab\\.com/.*${MOCK_GROUP_PATH}.*`;
+export const MOCK_URL_REGEX = `.*gitlab\.com/.*${MOCK_GROUP_PATH}.*`; // eslint-disable-line no-useless-escape

--- a/src/resolvers/mocks.ts
+++ b/src/resolvers/mocks.ts
@@ -14,4 +14,4 @@ export const MOCK_GROUP = {
   id: MOCK_GROUP_ID,
   path: MOCK_GROUP_PATH,
 };
-export const MOCK_URL_REGEX = `.*gitlab.com/.*${MOCK_GROUP_PATH}.*`;
+export const MOCK_URL_REGEX = `.*gitlab\.com/.*${MOCK_GROUP_PATH}.*`;


### PR DESCRIPTION
# Description

Previously added urlFilterRegex to all relevant synchronizeLinkAssociations calls. Now updated to escape . character to prevent it from matching anything.

Note: Deployed locally and tested that with a single escape, importing projects / syncing links works. 

# Checklist

Please ensure that each of these items has been addressed:

- [ X ] I have tested these changes in my local environment
- [ X ] I have added/modified tests as applicable to cover these changes
- [ X ] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links