### PR TITLE
Refactor handle push event so it only fetches commit diffs once

### DIFF
--- a/src/entry/webtriggers/gitlab-event-handlers/handle-push-event.test.ts
+++ b/src/entry/webtriggers/gitlab-event-handlers/handle-push-event.test.ts
@@ -308,7 +308,6 @@ describe('Gitlab push events', () => {
 
       await handlePushEvent(event, TEST_TOKEN, MOCK_CLOUD_ID);
 
-      expect(getCommitDiff).not.toBeCalled();
       expect(resyncRepoFiles).not.toBeCalled();
     });
 

--- a/src/entry/webtriggers/gitlab-event-handlers/handle-push-event.ts
+++ b/src/entry/webtriggers/gitlab-event-handlers/handle-push-event.ts
@@ -6,7 +6,7 @@ import {
 import { getCommitDiff } from '../../../client/gitlab';
 import { findConfigAsCodeFileChanges, syncComponent } from '../../../services/sync-component-with-file';
 import { isEventForTrackingBranch } from '../../../utils/push-event-utils';
-import { ComponentSyncDetails, PushEvent } from '../../../types';
+import { CommitFileDiff, ComponentSyncDetails, PushEvent } from '../../../types';
 import { getTrackingBranchName } from '../../../services/get-tracking-branch';
 import { unlinkComponentFromFile, resyncRepoFiles } from '../../../client/compass';
 import { EXTERNAL_SOURCE } from '../../../constants';
@@ -25,9 +25,21 @@ export const handlePushEvent = async (event: PushEvent, groupToken: string, clou
 
     console.log('Received push event for tracking branch. Processing event');
 
+    let commitDiffs: CommitFileDiff[] = [];
+    try {
+      commitDiffs = await getCommitDiff(groupToken, event.project.id, event.checkout_sha);
+    } catch (e) {
+      console.error({
+        message: 'Error with commits diff request',
+        error: e,
+      });
+      throw e;
+    }
+
     const { componentsToCreate, componentsToUpdate, componentsToUnlink } = await findConfigAsCodeFileChanges(
       event,
       groupToken,
+      commitDiffs,
     );
 
     if (componentsToCreate.length === 0 && componentsToUpdate.length === 0 && componentsToUnlink.length === 0) {
@@ -92,8 +104,6 @@ export const handlePushEvent = async (event: PushEvent, groupToken: string, clou
     }
 
     if (isPackageDependenciesM3Enabled()) {
-      const commitDiffs = await getCommitDiff(groupToken, event.project.id, event.checkout_sha);
-
       if (commitDiffs.length === 0) {
         console.log('No changes in commit, skipping resync of repo files');
       } else {

--- a/src/services/sync-component-with-file/find-config-file-changes.test.ts
+++ b/src/services/sync-component-with-file/find-config-file-changes.test.ts
@@ -40,7 +40,7 @@ const mockModifiedDiff = (fileBefore: CompassYaml, fileAfter: CompassYaml) => {
     new_path: 'compass.yml',
   });
 
-  getCommitDiffMock.mockResolvedValue([commitFileDiff]);
+  return [commitFileDiff];
 };
 
 const mockMovedDiffAsRename = (fileBefore: CompassYaml, fileAfter: CompassYaml) => {
@@ -50,7 +50,9 @@ const mockMovedDiffAsRename = (fileBefore: CompassYaml, fileAfter: CompassYaml) 
     new_path: 'folder/compass.yml',
   });
 
-  getCommitDiffMock.mockResolvedValue([commitFileDiff]);
+  // getCommitDiffMock.mockResolvedValue([commitFileDiff]);
+
+  return [commitFileDiff];
 };
 
 const mockMovedDiffAsAddedAndDeleted = (fileBefore: CompassYaml, fileAfter: CompassYaml) => {
@@ -65,7 +67,9 @@ const mockMovedDiffAsAddedAndDeleted = (fileBefore: CompassYaml, fileAfter: Comp
     new_path: 'folder/compass.yml',
   });
 
-  getCommitDiffMock.mockResolvedValue([commitFileDiffAdded, commitFileDiffDeleted]);
+  return [commitFileDiffAdded, commitFileDiffDeleted];
+
+  // getCommitDiffMock.mockResolvedValue([commitFileDiffAdded, commitFileDiffDeleted]);
 };
 
 describe('findConfigAsCodeFileChanges', () => {
@@ -84,7 +88,7 @@ describe('findConfigAsCodeFileChanges', () => {
       componentsToUnlink: [],
     };
 
-    const result = await findConfigAsCodeFileChanges(baseEvent, 'token');
+    const result = await findConfigAsCodeFileChanges(baseEvent, 'token', []);
     expect(result).toEqual(expectedResult);
   });
 
@@ -95,7 +99,6 @@ describe('findConfigAsCodeFileChanges', () => {
       old_path: 'compass.yml',
       new_path: 'compass.yml',
     });
-    getCommitDiffMock.mockResolvedValue([commitFileDiffAdded]);
     const expectedResult: ComponentChanges = {
       componentsToCreate: [
         {
@@ -108,7 +111,7 @@ describe('findConfigAsCodeFileChanges', () => {
       componentsToUnlink: [],
     };
 
-    const result = await findConfigAsCodeFileChanges(baseEvent, 'token');
+    const result = await findConfigAsCodeFileChanges(baseEvent, 'token', [commitFileDiffAdded]);
 
     expect(result).toEqual(expectedResult);
   });
@@ -120,7 +123,7 @@ describe('findConfigAsCodeFileChanges', () => {
       old_path: 'compass.yml',
       new_path: 'compass.yml',
     });
-    getCommitDiffMock.mockResolvedValue([commitFileDiffRemoved]);
+    // getCommitDiffMock.mockResolvedValue([commitFileDiffRemoved]);
     const expectedResult: ComponentChanges = {
       componentsToCreate: [],
       componentsToUpdate: [],
@@ -133,7 +136,7 @@ describe('findConfigAsCodeFileChanges', () => {
       ],
     };
 
-    const result = await findConfigAsCodeFileChanges(baseEvent, 'token');
+    const result = await findConfigAsCodeFileChanges(baseEvent, 'token', [commitFileDiffRemoved]);
 
     expect(result).toEqual(expectedResult);
   });
@@ -141,7 +144,6 @@ describe('findConfigAsCodeFileChanges', () => {
   it('updates component', async () => {
     const compassYamlBefore = { id: 'id', description: 'desc1' };
     const compassYamlAfter = { id: 'id', description: 'desc2' };
-    mockModifiedDiff(compassYamlBefore, compassYamlAfter);
 
     const expectedResult: ComponentChanges = {
       componentsToCreate: [],
@@ -156,7 +158,11 @@ describe('findConfigAsCodeFileChanges', () => {
       componentsToUnlink: [],
     };
 
-    const result = await findConfigAsCodeFileChanges(baseEvent, 'token');
+    const result = await findConfigAsCodeFileChanges(
+      baseEvent,
+      'token',
+      mockModifiedDiff(compassYamlBefore, compassYamlAfter),
+    );
 
     expect(result).toEqual(expectedResult);
   });
@@ -164,7 +170,6 @@ describe('findConfigAsCodeFileChanges', () => {
   it('updates component when the config file moved with minimum changes and treated by Gitlab as rename', async () => {
     const compassYamlBefore = { id: 'id' };
     const compassYamlAfter = { id: 'id' };
-    mockMovedDiffAsRename(compassYamlBefore, compassYamlAfter);
 
     const expectedResult: ComponentChanges = {
       componentsToCreate: [],
@@ -179,7 +184,11 @@ describe('findConfigAsCodeFileChanges', () => {
       componentsToUnlink: [],
     };
 
-    const result = await findConfigAsCodeFileChanges(baseEvent, 'token');
+    const result = await findConfigAsCodeFileChanges(
+      baseEvent,
+      'token',
+      mockMovedDiffAsRename(compassYamlBefore, compassYamlAfter),
+    );
 
     expect(result).toEqual(expectedResult);
   });
@@ -187,7 +196,6 @@ describe('findConfigAsCodeFileChanges', () => {
   it('updates component when the config file moved with minimum changes and treated by Gitlab as two files - deleted and added', async () => {
     const compassYamlBefore = { id: 'id' };
     const compassYamlAfter = { id: 'id' };
-    mockMovedDiffAsAddedAndDeleted(compassYamlBefore, compassYamlAfter);
 
     const expectedResult: ComponentChanges = {
       componentsToCreate: [],
@@ -202,7 +210,11 @@ describe('findConfigAsCodeFileChanges', () => {
       componentsToUnlink: [],
     };
 
-    const result = await findConfigAsCodeFileChanges(baseEvent, 'token');
+    const result = await findConfigAsCodeFileChanges(
+      baseEvent,
+      'token',
+      mockMovedDiffAsAddedAndDeleted(compassYamlBefore, compassYamlAfter),
+    );
 
     expect(result).toEqual(expectedResult);
   });
@@ -210,7 +222,6 @@ describe('findConfigAsCodeFileChanges', () => {
   it('unlinks component and adds new one when the id changed', async () => {
     const compassYamlBefore = { id: 'id1' };
     const compassYamlAfter = { id: 'id2' };
-    mockModifiedDiff(compassYamlBefore, compassYamlAfter);
     const expectedResult: ComponentChanges = {
       componentsToCreate: [
         {
@@ -231,7 +242,11 @@ describe('findConfigAsCodeFileChanges', () => {
       ],
     };
 
-    const result = await findConfigAsCodeFileChanges(baseEvent, 'token');
+    const result = await findConfigAsCodeFileChanges(
+      baseEvent,
+      'token',
+      mockModifiedDiff(compassYamlBefore, compassYamlAfter),
+    );
 
     expect(result).toEqual(expectedResult);
   });
@@ -247,7 +262,6 @@ describe('findConfigAsCodeFileChanges', () => {
     test('updates component when the id added and the name is the same', async () => {
       const compassYamlBefore = { name: 'name' };
       const compassYamlAfter = { name: 'name', id: 'id' };
-      mockModifiedDiff(compassYamlBefore, compassYamlAfter);
 
       const expectedResult: ComponentChanges = {
         componentsToCreate: [],
@@ -262,7 +276,11 @@ describe('findConfigAsCodeFileChanges', () => {
         componentsToUnlink: [],
       };
 
-      const result = await findConfigAsCodeFileChanges(event, 'token');
+      const result = await findConfigAsCodeFileChanges(
+        event,
+        'token',
+        mockModifiedDiff(compassYamlBefore, compassYamlAfter),
+      );
 
       expect(result).toEqual(expectedResult);
     });
@@ -270,7 +288,6 @@ describe('findConfigAsCodeFileChanges', () => {
     test('updates component when the id added and the name is changed', async () => {
       const compassYamlBefore = { name: 'name' };
       const compassYamlAfter = { name: 'name-2', id: 'id' };
-      mockModifiedDiff(compassYamlBefore, compassYamlAfter);
 
       const expectedResult: ComponentChanges = {
         componentsToCreate: [],
@@ -284,7 +301,11 @@ describe('findConfigAsCodeFileChanges', () => {
         ],
         componentsToUnlink: [],
       };
-      const result = await findConfigAsCodeFileChanges(event, 'token');
+      const result = await findConfigAsCodeFileChanges(
+        event,
+        'token',
+        mockModifiedDiff(compassYamlBefore, compassYamlAfter),
+      );
 
       expect(result).toEqual(expectedResult);
     });
@@ -292,7 +313,6 @@ describe('findConfigAsCodeFileChanges', () => {
     test('updates component when the config file moved with minimum changes, same name, added id and moved with minimum changes that treated by Gitlab as rename', async () => {
       const compassYamlBefore = { name: 'name' };
       const compassYamlAfter = { name: 'name', id: 'id' };
-      mockMovedDiffAsRename(compassYamlBefore, compassYamlAfter);
 
       const expectedResult: ComponentChanges = {
         componentsToCreate: [],
@@ -306,7 +326,11 @@ describe('findConfigAsCodeFileChanges', () => {
         ],
         componentsToUnlink: [],
       };
-      const result = await findConfigAsCodeFileChanges(event, 'token');
+      const result = await findConfigAsCodeFileChanges(
+        event,
+        'token',
+        mockMovedDiffAsRename(compassYamlBefore, compassYamlAfter),
+      );
 
       expect(result).toEqual(expectedResult);
     });
@@ -314,7 +338,6 @@ describe('findConfigAsCodeFileChanges', () => {
     test('updates component when the config file moved with major changes same name, added id and moved with major changes that treated by Gitlab as two files - deleted and added', async () => {
       const compassYamlBefore = { name: 'name' };
       const compassYamlAfter = { name: 'name', id: 'id' };
-      mockMovedDiffAsAddedAndDeleted(compassYamlBefore, compassYamlAfter);
 
       const expectedResult: ComponentChanges = {
         componentsToCreate: [],
@@ -328,7 +351,11 @@ describe('findConfigAsCodeFileChanges', () => {
         ],
         componentsToUnlink: [],
       };
-      const result = await findConfigAsCodeFileChanges(event, 'token');
+      const result = await findConfigAsCodeFileChanges(
+        event,
+        'token',
+        mockMovedDiffAsAddedAndDeleted(compassYamlBefore, compassYamlAfter),
+      );
 
       expect(result).toEqual(expectedResult);
     });
@@ -336,7 +363,6 @@ describe('findConfigAsCodeFileChanges', () => {
     test('unlinks component and adds the new one when the id removed and the name is the same', async () => {
       const compassYamlBefore = { name: 'name', id: 'id' };
       const compassYamlAfter = { name: 'name' };
-      mockModifiedDiff(compassYamlBefore, compassYamlAfter);
 
       const expectedResult: ComponentChanges = {
         componentsToCreate: [
@@ -357,7 +383,11 @@ describe('findConfigAsCodeFileChanges', () => {
           },
         ],
       };
-      const result = await findConfigAsCodeFileChanges(event, 'token');
+      const result = await findConfigAsCodeFileChanges(
+        event,
+        'token',
+        mockModifiedDiff(compassYamlBefore, compassYamlAfter),
+      );
 
       expect(result).toEqual(expectedResult);
     });
@@ -365,7 +395,6 @@ describe('findConfigAsCodeFileChanges', () => {
     test('unlinks component and adds the new one when the name changed and id removed', async () => {
       const compassYamlBefore = { name: 'name', id: 'id' };
       const compassYamlAfter = { name: 'name-2' };
-      mockModifiedDiff(compassYamlBefore, compassYamlAfter);
 
       const expectedResult: ComponentChanges = {
         componentsToCreate: [
@@ -386,7 +415,11 @@ describe('findConfigAsCodeFileChanges', () => {
           },
         ],
       };
-      const result = await findConfigAsCodeFileChanges(event, 'token');
+      const result = await findConfigAsCodeFileChanges(
+        event,
+        'token',
+        mockModifiedDiff(compassYamlBefore, compassYamlAfter),
+      );
 
       expect(result).toEqual(expectedResult);
     });
@@ -395,8 +428,6 @@ describe('findConfigAsCodeFileChanges', () => {
       const compassYamlBefore = { name: 'name', description: 'desc1' };
       const compassYamlAfter = { name: 'name', description: 'desc2' };
 
-      mockModifiedDiff(compassYamlBefore, compassYamlAfter);
-
       const expectedResult: ComponentChanges = {
         componentsToCreate: [],
         componentsToUpdate: [
@@ -409,7 +440,11 @@ describe('findConfigAsCodeFileChanges', () => {
         ],
         componentsToUnlink: [],
       };
-      const result = await findConfigAsCodeFileChanges(event, 'token');
+      const result = await findConfigAsCodeFileChanges(
+        event,
+        'token',
+        mockModifiedDiff(compassYamlBefore, compassYamlAfter),
+      );
 
       expect(result).toEqual(expectedResult);
     });
@@ -417,7 +452,6 @@ describe('findConfigAsCodeFileChanges', () => {
     test('updates component when the name changed', async () => {
       const compassYamlBefore = { name: 'name' };
       const compassYamlAfter = { name: 'name2' };
-      mockModifiedDiff(compassYamlBefore, compassYamlAfter);
 
       const expectedResult: ComponentChanges = {
         componentsToCreate: [],
@@ -431,7 +465,11 @@ describe('findConfigAsCodeFileChanges', () => {
         ],
         componentsToUnlink: [],
       };
-      const result = await findConfigAsCodeFileChanges(event, 'token');
+      const result = await findConfigAsCodeFileChanges(
+        event,
+        'token',
+        mockModifiedDiff(compassYamlBefore, compassYamlAfter),
+      );
 
       expect(result).toEqual(expectedResult);
     });
@@ -450,7 +488,6 @@ describe('findConfigAsCodeFileChanges', () => {
           renamed_file: false,
           deleted_file: false,
         };
-        getCommitDiffMock.mockResolvedValue([commitFileDiff]);
 
         const expectedResult: ComponentChanges = {
           componentsToCreate: [],
@@ -464,7 +501,7 @@ describe('findConfigAsCodeFileChanges', () => {
           ],
           componentsToUnlink: [],
         };
-        const result = await findConfigAsCodeFileChanges(event, 'token');
+        const result = await findConfigAsCodeFileChanges(event, 'token', [commitFileDiff]);
 
         expect(result).toEqual(expectedResult);
       });
@@ -482,7 +519,6 @@ describe('findConfigAsCodeFileChanges', () => {
           renamed_file: false,
           deleted_file: false,
         };
-        getCommitDiffMock.mockResolvedValue([commitFileDiff]);
 
         const expectedResult: ComponentChanges = {
           componentsToCreate: [],
@@ -496,7 +532,7 @@ describe('findConfigAsCodeFileChanges', () => {
           ],
           componentsToUnlink: [],
         };
-        const result = await findConfigAsCodeFileChanges(event, 'token');
+        const result = await findConfigAsCodeFileChanges(event, 'token', [commitFileDiff]);
 
         expect(result).toEqual(expectedResult);
       });
@@ -512,14 +548,13 @@ describe('findConfigAsCodeFileChanges', () => {
           renamed_file: false,
           deleted_file: false,
         };
-        getCommitDiffMock.mockResolvedValue([commitFileDiff]);
 
         const expectedResult: ComponentChanges = {
           componentsToCreate: [],
           componentsToUpdate: [],
           componentsToUnlink: [],
         };
-        const result = await findConfigAsCodeFileChanges(event, 'token');
+        const result = await findConfigAsCodeFileChanges(event, 'token', [commitFileDiff]);
 
         expect(result).toEqual(expectedResult);
       });
@@ -535,14 +570,13 @@ describe('findConfigAsCodeFileChanges', () => {
           renamed_file: false,
           deleted_file: true,
         };
-        getCommitDiffMock.mockResolvedValue([commitFileDiff]);
 
         const expectedResult: ComponentChanges = {
           componentsToCreate: [],
           componentsToUpdate: [],
           componentsToUnlink: [],
         };
-        const result = await findConfigAsCodeFileChanges(event, 'token');
+        const result = await findConfigAsCodeFileChanges(event, 'token', [commitFileDiff]);
 
         expect(result).toEqual(expectedResult);
       });
@@ -551,7 +585,6 @@ describe('findConfigAsCodeFileChanges', () => {
     test('updates component by name when the config file moved with minimum changes and treated by Gitlab as rename', async () => {
       const compassYamlBefore = { name: 'name' };
       const compassYamlAfter = { name: 'name' };
-      mockMovedDiffAsRename(compassYamlBefore, compassYamlAfter);
 
       const expectedResult: ComponentChanges = {
         componentsToCreate: [],
@@ -565,7 +598,11 @@ describe('findConfigAsCodeFileChanges', () => {
         ],
         componentsToUnlink: [],
       };
-      const result = await findConfigAsCodeFileChanges(event, 'token');
+      const result = await findConfigAsCodeFileChanges(
+        event,
+        'token',
+        mockMovedDiffAsRename(compassYamlBefore, compassYamlAfter),
+      );
 
       expect(result).toEqual(expectedResult);
     });
@@ -573,7 +610,6 @@ describe('findConfigAsCodeFileChanges', () => {
     test('updates component by name when the config file moved with major changes and treated by Gitlab as two files - deleted and added', async () => {
       const compassYamlBefore = { name: 'name' };
       const compassYamlAfter = { name: 'name' };
-      mockMovedDiffAsAddedAndDeleted(compassYamlBefore, compassYamlAfter);
 
       const expectedResult: ComponentChanges = {
         componentsToCreate: [],
@@ -587,7 +623,11 @@ describe('findConfigAsCodeFileChanges', () => {
         ],
         componentsToUnlink: [],
       };
-      const result = await findConfigAsCodeFileChanges(event, 'token');
+      const result = await findConfigAsCodeFileChanges(
+        event,
+        'token',
+        mockMovedDiffAsAddedAndDeleted(compassYamlBefore, compassYamlAfter),
+      );
 
       expect(result).toEqual(expectedResult);
     });
@@ -595,7 +635,6 @@ describe('findConfigAsCodeFileChanges', () => {
     test('updates component by id when the config file moved with minimum changes and treated by Gitlab as rename', async () => {
       const compassYamlBefore = { id: 'id' };
       const compassYamlAfter = { id: 'id' };
-      mockMovedDiffAsRename(compassYamlBefore, compassYamlAfter);
 
       const expectedResult: ComponentChanges = {
         componentsToCreate: [],
@@ -609,7 +648,11 @@ describe('findConfigAsCodeFileChanges', () => {
         ],
         componentsToUnlink: [],
       };
-      const result = await findConfigAsCodeFileChanges(event, 'token');
+      const result = await findConfigAsCodeFileChanges(
+        event,
+        'token',
+        mockMovedDiffAsRename(compassYamlBefore, compassYamlAfter),
+      );
 
       expect(result).toEqual(expectedResult);
     });
@@ -617,7 +660,6 @@ describe('findConfigAsCodeFileChanges', () => {
     test('updates component by id when the config file moved with major changes and treated by Gitlab as two files - deleted and added', async () => {
       const compassYamlBefore = { id: 'id' };
       const compassYamlAfter = { id: 'id' };
-      mockMovedDiffAsAddedAndDeleted(compassYamlBefore, compassYamlAfter);
 
       const expectedResult: ComponentChanges = {
         componentsToCreate: [],
@@ -631,7 +673,11 @@ describe('findConfigAsCodeFileChanges', () => {
         ],
         componentsToUnlink: [],
       };
-      const result = await findConfigAsCodeFileChanges(event, 'token');
+      const result = await findConfigAsCodeFileChanges(
+        event,
+        'token',
+        mockMovedDiffAsAddedAndDeleted(compassYamlBefore, compassYamlAfter),
+      );
 
       expect(result).toEqual(expectedResult);
     });
@@ -639,7 +685,6 @@ describe('findConfigAsCodeFileChanges', () => {
     test('unlinks component and adds the new one when the config file has changed name and moved with minimum changes, that treated by Gitlab as rename', async () => {
       const compassYamlBefore = { name: 'name' };
       const compassYamlAfter = { name: 'name2' };
-      mockMovedDiffAsRename(compassYamlBefore, compassYamlAfter);
 
       const expectedResult: ComponentChanges = {
         componentsToCreate: [
@@ -660,7 +705,11 @@ describe('findConfigAsCodeFileChanges', () => {
           },
         ],
       };
-      const result = await findConfigAsCodeFileChanges(event, 'token');
+      const result = await findConfigAsCodeFileChanges(
+        event,
+        'token',
+        mockMovedDiffAsRename(compassYamlBefore, compassYamlAfter),
+      );
 
       expect(result).toEqual(expectedResult);
     });
@@ -668,7 +717,6 @@ describe('findConfigAsCodeFileChanges', () => {
     test('unlinks component and adds the new one when the config file has changed name and moved with major changes, that treated by Gitlab as two files - deleted and added', async () => {
       const compassYamlBefore = { name: 'name' };
       const compassYamlAfter = { name: 'name2' };
-      mockMovedDiffAsAddedAndDeleted(compassYamlBefore, compassYamlAfter);
 
       const expectedResult: ComponentChanges = {
         componentsToCreate: [
@@ -687,7 +735,11 @@ describe('findConfigAsCodeFileChanges', () => {
           },
         ],
       };
-      const result = await findConfigAsCodeFileChanges(event, 'token');
+      const result = await findConfigAsCodeFileChanges(
+        event,
+        'token',
+        mockMovedDiffAsAddedAndDeleted(compassYamlBefore, compassYamlAfter),
+      );
 
       expect(result).toEqual(expectedResult);
     });
@@ -695,7 +747,6 @@ describe('findConfigAsCodeFileChanges', () => {
     test('unlinks component and adds the new one when the config file has same name, removed id and moved with minimum changes that treated by Gitlab as rename', async () => {
       const compassYamlBefore = { name: 'name', id: 'id' };
       const compassYamlAfter = { name: 'name' };
-      mockMovedDiffAsRename(compassYamlBefore, compassYamlAfter);
 
       const expectedResult: ComponentChanges = {
         componentsToCreate: [
@@ -716,7 +767,11 @@ describe('findConfigAsCodeFileChanges', () => {
           },
         ],
       };
-      const result = await findConfigAsCodeFileChanges(event, 'token');
+      const result = await findConfigAsCodeFileChanges(
+        event,
+        'token',
+        mockMovedDiffAsRename(compassYamlBefore, compassYamlAfter),
+      );
 
       expect(result).toEqual(expectedResult);
     });
@@ -724,7 +779,6 @@ describe('findConfigAsCodeFileChanges', () => {
     test('unlinks component and adds the new one when the config file has same name, removed id and moved with major changes that treated by Gitlab as two files - deleted and added', async () => {
       const compassYamlBefore = { name: 'name', id: 'id' };
       const compassYamlAfter = { name: 'name' };
-      mockMovedDiffAsAddedAndDeleted(compassYamlBefore, compassYamlAfter);
 
       const expectedResult: ComponentChanges = {
         componentsToCreate: [
@@ -743,7 +797,11 @@ describe('findConfigAsCodeFileChanges', () => {
           },
         ],
       };
-      const result = await findConfigAsCodeFileChanges(event, 'token');
+      const result = await findConfigAsCodeFileChanges(
+        event,
+        'token',
+        mockMovedDiffAsAddedAndDeleted(compassYamlBefore, compassYamlAfter),
+      );
 
       expect(result).toEqual(expectedResult);
     });

--- a/src/services/sync-component-with-file/find-config-file-changes.ts
+++ b/src/services/sync-component-with-file/find-config-file-changes.ts
@@ -113,18 +113,11 @@ const getModifiedFiles = async (
     .map((result) => (result as PromiseFulfilledResult<ModifiedFilePayload>).value);
 };
 
-export const findConfigAsCodeFileChanges = async (event: PushEvent, token: string): Promise<ComponentChanges> => {
-  let filesDiffs: CommitFileDiff[] = [];
-  try {
-    filesDiffs = await getCommitDiff(token, event.project.id, event.checkout_sha);
-  } catch (e) {
-    console.error({
-      message: 'Error with commits diff request',
-      error: e,
-    });
-    throw e;
-  }
-
+export const findConfigAsCodeFileChanges = async (
+  event: PushEvent,
+  token: string,
+  filesDiffs: CommitFileDiff[],
+): Promise<ComponentChanges> => {
   const { added, removed, modified } = groupDiffsByChangeType(filesDiffs);
 
   if (added.length === 0 && removed.length === 0 && modified.length === 0) {


### PR DESCRIPTION
# Description

Refactor `handle-push-event` to only make an API call to `getCommitDiff` once by combining the CAC's and package dependencies resyncing's call.
Verified a CAC file change and package-lock.json file change still works locally.

# Checklist

Please ensure that each of these items has been addressed:

- [x ] I have tested these changes in my local environment
- [x] I have added/modified tests as applicable to cover these changes
- [x ] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links