### PR TITLE
Return empty instead of error from findMatchingFiles when FF off

### DIFF
--- a/src/entry/find-matching-files/index.ts
+++ b/src/entry/find-matching-files/index.ts
@@ -49,9 +49,8 @@ const getMatchingFiles = (files: ProjectFile[], containsOneOf: string[], equalsO
 export const findMatchingFiles = async (payload: FindMatchingFilesPayload): Promise<FindMatchingFilesResponse> => {
   if (!isPackageDependenciesM3Enabled()) {
     return {
-      success: false,
-      errorMessage: 'Feature not implemented.',
-      statusCode: 405,
+      success: true,
+      statusCode: 200,
       files: [],
     };
   }

--- a/src/entry/find-matching-files/test.ts
+++ b/src/entry/find-matching-files/test.ts
@@ -128,15 +128,17 @@ describe('findMatchingFiles', () => {
     });
   });
 
-  it('should return 405 if the feature is not enabled', async () => {
+  it('should return 200 and empty files array if the feature is not enabled', async () => {
     jest.spyOn(featureFlagService, 'isPackageDependenciesM3Enabled').mockReturnValue(false);
 
     const result = await findMatchingFiles(mockPayload);
 
+    expect(mockedGetProjectDataFromUrl).not.toHaveBeenCalled();
+    expect(listFiles).not.toHaveBeenCalled();
+
     expect(result).toEqual({
-      success: false,
-      errorMessage: 'Feature not implemented.',
-      statusCode: 405,
+      success: true,
+      statusCode: 200,
       files: [],
     });
   });


### PR DESCRIPTION
# Description

Changes the behavior of `findMatchingFiles` to return an empty array when the package dependencies M3 feature gate is disabled, instead of returning an error.

# Checklist

Please ensure that each of these items has been addressed:

- [ ] I have tested these changes in my local environment
- [ X ] I have added/modified tests as applicable to cover these changes
- [ X ] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links