### PR TITLE
Fix issue with blocking querying CaC files

### DIFF
--- a/src/resolvers/admin-resolvers.ts
+++ b/src/resolvers/admin-resolvers.ts
@@ -240,14 +240,6 @@ resolver.define('group/resyncCaC', async (req): Promise<ResolverResponse<{ hasNe
 
     const dateNowInMs = Date.now();
 
-    if (!lastUpdate) {
-      await storage.set(`${STORAGE_KEYS.CAC_MANUAL_SYNC_PREFIX}${cloudId}_${groupId}`, dateNowInMs);
-    }
-
-    if (lastUpdate && dateNowInMs - lastUpdate > minutesToMilliseconds(MINUTES_LOCK)) {
-      await storage.set(`${STORAGE_KEYS.CAC_MANUAL_SYNC_PREFIX}${cloudId}_${groupId}`, dateNowInMs);
-    }
-
     if (lastUpdate && dateNowInMs - lastUpdate <= minutesToMilliseconds(MINUTES_LOCK)) {
       return {
         success: true,
@@ -291,6 +283,14 @@ resolver.define('group/resyncCaC', async (req): Promise<ResolverResponse<{ hasNe
       }
 
       await resyncConfigAsCode(cloudId, yamlFilesData);
+    }
+
+    if (!lastUpdate && !hasNextPage) {
+      await storage.set(`${STORAGE_KEYS.CAC_MANUAL_SYNC_PREFIX}${cloudId}_${groupId}`, dateNowInMs);
+    }
+
+    if (lastUpdate && dateNowInMs - lastUpdate > minutesToMilliseconds(MINUTES_LOCK) && !hasNextPage) {
+      await storage.set(`${STORAGE_KEYS.CAC_MANUAL_SYNC_PREFIX}${cloudId}_${groupId}`, dateNowInMs);
     }
 
     return {

--- a/src/services/files.ts
+++ b/src/services/files.ts
@@ -24,7 +24,7 @@ export const getGroupCaCFiles = async ({
       search: searchQuery,
     });
 
-    const hasNextPage = headers.get(GitLabHeaders.PAGINATION_NEXT_PAGE) !== undefined;
+    const hasNextPage = Boolean(headers.get(GitLabHeaders.PAGINATION_NEXT_PAGE));
 
     return {
       data,


### PR DESCRIPTION
# Description

Fix the issue with blocking querying CaC files. Added a timestamp to the storage after querying all CaC files, as we previously only queried the first page and blocked this process.

# Checklist

Please ensure that each of these items has been addressed:

- [X] I have tested these changes in my local environment
- [X] I have added/modified tests as applicable to cover these changes
- [X] (Atlassian contributors only) I have removed any Atlassian-internal changes including internal modules, references to internal tickets, and internal wiki links